### PR TITLE
SortExec spill optimizing

### DIFF
--- a/native-engine/datafusion-ext-commons/src/io/batch_serde.rs
+++ b/native-engine/datafusion-ext-commons/src/io/batch_serde.rs
@@ -225,8 +225,7 @@ fn write_bits_buffer<W: Write>(
 }
 
 fn read_bits_buffer<R: Read>(input: &mut R, bits_len: usize) -> Result<Buffer> {
-    let buf = read_bytes_slice(input, (bits_len + 7) / 8)
-        .map_err(|err| err.context("batch_serde: error reading bit buffer"))?;
+    let buf = read_bytes_slice(input, (bits_len + 7) / 8)?;
     Ok(Buffer::from(buf))
 }
 

--- a/native-engine/datafusion-ext-commons/src/io/mod.rs
+++ b/native-engine/datafusion-ext-commons/src/io/mod.rs
@@ -75,7 +75,7 @@ pub fn name_batch(batch: RecordBatch, name_schema: &SchemaRef) -> Result<RecordB
     )?)?))
 }
 
-pub fn write_len<W: Write>(mut len: usize, output: &mut W) -> Result<()> {
+pub fn write_len<W: Write>(mut len: usize, output: &mut W) -> std::io::Result<()> {
     while len >= 128 {
         let v = len % 128;
         len /= 128;
@@ -85,7 +85,7 @@ pub fn write_len<W: Write>(mut len: usize, output: &mut W) -> Result<()> {
     Ok(())
 }
 
-pub fn read_len<R: Read>(input: &mut R) -> Result<usize> {
+pub fn read_len<R: Read>(input: &mut R) -> std::io::Result<usize> {
     let mut len = 0usize;
     let mut factor = 1;
     loop {
@@ -100,18 +100,18 @@ pub fn read_len<R: Read>(input: &mut R) -> Result<usize> {
     Ok(len)
 }
 
-pub fn write_u8<W: Write>(n: u8, output: &mut W) -> Result<()> {
+pub fn write_u8<W: Write>(n: u8, output: &mut W) -> std::io::Result<()> {
     output.write_all(&[n])?;
     Ok(())
 }
 
-pub fn read_u8<R: Read>(input: &mut R) -> Result<u8> {
+pub fn read_u8<R: Read>(input: &mut R) -> std::io::Result<u8> {
     let mut buf = [0; 1];
     input.read_exact(&mut buf)?;
     Ok(buf[0])
 }
 
-pub fn read_bytes_slice<R: Read>(input: &mut R, len: usize) -> Result<Box<[u8]>> {
+pub fn read_bytes_slice<R: Read>(input: &mut R, len: usize) -> std::io::Result<Box<[u8]>> {
     // safety - assume_init() is safe for [u8]
     let mut byte_slice = unsafe { Box::new_uninit_slice(len).assume_init() };
     input.read_exact(byte_slice.as_mut())?;

--- a/native-engine/datafusion-ext-plans/src/agg/acc.rs
+++ b/native-engine/datafusion-ext-plans/src/agg/acc.rs
@@ -570,7 +570,7 @@ pub fn create_dyn_savers_from_initial_value(values: &[AccumInitialValue]) -> Res
                                 return write_scalar(scalar, false, &mut w.0);
                             }
                         }
-                        return write_u8(0, &mut w.0);
+                        return Ok(write_u8(0, &mut w.0)?);
                     }
                     let f: SaveFn = Box::new(f);
                     f

--- a/native-engine/datafusion-ext-plans/src/common/mod.rs
+++ b/native-engine/datafusion-ext-plans/src/common/mod.rs
@@ -57,7 +57,7 @@ fn compute_batch_size_with_target_mem_size(
     if num_rows == 0 {
         return batch_size;
     }
-    let est_mem_size_per_row = mem_size / num_rows;
-    let est_sub_batch_size = target_mem_size / est_mem_size_per_row;
+    let est_mem_size_per_row = mem_size.max(16) / num_rows.max(1);
+    let est_sub_batch_size = target_mem_size / est_mem_size_per_row.max(16);
     est_sub_batch_size.min(batch_size).max(batch_size_min)
 }


### PR DESCRIPTION
use more precise memory usage in SortExec.

use multi-level spill merging in SortExec.
