### PR TITLE
release version 2.0.9

### DIFF
--- a/.github/workflows/build-ce7-releases.yml
+++ b/.github/workflows/build-ce7-releases.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         sparkver: [spark303, spark333]
-        blazever: [2.0.8]
+        blazever: [2.0.9]
 
     steps:
       - uses: actions/checkout@v4

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,32 +1,23 @@
-# blaze-v2.0.8
+# blaze-v2.0.9
 
 ## Features
-* Enables nested complex data types by default.
-* Supports writing parquet table with dynamic partitions.
-* Supports partial aggregate skipping.
-* Enable first() aggregate function converting.
-* Add spill metrics.
-*
+* Upgrades datafusion/arrow dependency version to v36/v50.
+* Supports max/min aggregation with complex types.
+* Supports json_tuple.
+* Introduce sonic-rs for json parsing.
+* Add stage id in operator metrics.
+* Implements writing table with dynamic partitions (not tested in spark303/spark333).
+
 ## Performance
-* Implement batch updating/merging in aggregates.
-* Use slim box for storing bytes.
-* get_json_object use Cow to avoid copying.
-* Reduce the probability of unexpected off-heap memory overflows.
-* Introduce multiway merge sort to SortExec and SortRepartitioner.
-* SortExec removes redundant columns from batch.
-* Implement loser tree with inlined comparable traits.
-* Use unchecked index in LoserTree to get slightly performance improvement.
-* Remove BucketRepartitioner.
-* Reduce number of awaits in sort-merge join.
-* Pre-merge records in sorting mode if cardinality is low.
-* Use gxhash as default hasher in AggExec.
-* Optimize collect_set/collect_list function with SmallVec.
-* Implement async ipc reader.
+* Improves batch serialization format and reduce compressed size.
+* Implements radix-based k-way merging used in shuffling and aggregating.
+* Improves performance of on-heap spilling.
+* Improves performance of SortExec.
+* Improves performance of AggExec.
+* Improves performance of collect_set/collect_list.
 
 ## Bugfix
-* Fix buggy GetArrayItem/GetMapValue native converter pattern matching.
-* Fix parquet pruning with NaN values.
-* Fix map type conversion with incorrect nullable value.
-* Fix ffi-export error in some cases.
-* Fix incorrect behavior of get_index_field with incorrect number of rows.
-* Fix task hanging in some cases with ffi-export.
+* Fix concat_ws with empty batches.
+* Fix spark333 RenameExec incorrect ordering expressions.
+* Fix incorrect join type mapping in BroadcastNestedLoopJoin.
+* Fix decimal dividing with zero.

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   </modules>
 
   <properties>
-    <revision>2.0.8.1-SNAPSHOT</revision>
+    <revision>2.0.9-SNAPSHOT</revision>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <arrowVersion>14.0.1</arrowVersion>
     <protobufVersion>3.21.9</protobufVersion>


### PR DESCRIPTION
# blaze-v2.0.9

## Features
* Upgrades datafusion/arrow dependency version to v36/v50.
* Supports max/min aggregation with complex types.
* Supports json_tuple.
* Introduce sonic-rs for json parsing.
* Add stage id in operator metrics.
* Implements writing table with dynamic partitions (not tested in spark303/spark333).

## Performance
* Improves batch serialization format and reduce compressed size.
* Implements radix-based k-way merging used in shuffling and aggregating.
* Improves performance of on-heap spilling.
* Improves performance of SortExec.
* Improves performance of AggExec.
* Improves performance of collect_set/collect_list.

## Bugfix
* Fix concat_ws with empty batches.
* Fix spark333 RenameExec incorrect ordering expressions.
* Fix incorrect join type mapping in BroadcastNestedLoopJoin.
* Fix decimal dividing with zero.
