### PR TITLE
use adaptive batch size during parquet scanning.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,7 +755,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=5d6b63a#5d6b63abf96d489942a42722ca3e483b4da86ca9"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=90b13d32d#90b13d32d029b95278e5a2317631d870402835be"
 dependencies = [
  "ahash",
  "arrow",
@@ -804,7 +804,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=5d6b63a#5d6b63abf96d489942a42722ca3e483b4da86ca9"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=90b13d32d#90b13d32d029b95278e5a2317631d870402835be"
 dependencies = [
  "ahash",
  "arrow",
@@ -823,7 +823,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=5d6b63a#5d6b63abf96d489942a42722ca3e483b4da86ca9"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=90b13d32d#90b13d32d029b95278e5a2317631d870402835be"
 dependencies = [
  "arrow",
  "chrono",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=5d6b63a#5d6b63abf96d489942a42722ca3e483b4da86ca9"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=90b13d32d#90b13d32d029b95278e5a2317631d870402835be"
 dependencies = [
  "ahash",
  "arrow",
@@ -960,7 +960,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=5d6b63a#5d6b63abf96d489942a42722ca3e483b4da86ca9"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=90b13d32d#90b13d32d029b95278e5a2317631d870402835be"
 dependencies = [
  "arrow",
  "base64 0.21.7",
@@ -974,7 +974,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-array"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=5d6b63a#5d6b63abf96d489942a42722ca3e483b4da86ca9"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=90b13d32d#90b13d32d029b95278e5a2317631d870402835be"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -987,7 +987,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=5d6b63a#5d6b63abf96d489942a42722ca3e483b4da86ca9"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=90b13d32d#90b13d32d029b95278e5a2317631d870402835be"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1004,7 +1004,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=5d6b63a#5d6b63abf96d489942a42722ca3e483b4da86ca9"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=90b13d32d#90b13d32d029b95278e5a2317631d870402835be"
 dependencies = [
  "ahash",
  "arrow",
@@ -1039,7 +1039,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=5d6b63a#5d6b63abf96d489942a42722ca3e483b4da86ca9"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=90b13d32d#90b13d32d029b95278e5a2317631d870402835be"
 dependencies = [
  "ahash",
  "arrow",
@@ -1069,7 +1069,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=5d6b63a#5d6b63abf96d489942a42722ca3e483b4da86ca9"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=90b13d32d#90b13d32d029b95278e5a2317631d870402835be"
 dependencies = [
  "arrow",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,12 +64,12 @@ serde_json = { version = "1.0.96" }
 
 [patch.crates-io]
 # datafusion: branch=v30-blaze
-datafusion = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "5d6b63a"}
-datafusion-common = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "5d6b63a"}
-datafusion-expr = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "5d6b63a"}
-datafusion-execution = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "5d6b63a"}
-datafusion-optimizer = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "5d6b63a"}
-datafusion-physical-expr = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "5d6b63a"}
+datafusion = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "90b13d32d"}
+datafusion-common = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "90b13d32d"}
+datafusion-expr = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "90b13d32d"}
+datafusion-execution = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "90b13d32d"}
+datafusion-optimizer = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "90b13d32d"}
+datafusion-physical-expr = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "90b13d32d"}
 
 # arrow: branch=v45-blaze
 arrow = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "4d46e9e1f0"}

--- a/native-engine/datafusion-ext-plans/src/parquet_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/parquet_exec.rs
@@ -229,12 +229,10 @@ impl ExecutionPlan for ParquetExec {
             None => (0..self.base_config.file_schema.fields().len()).collect(),
         };
 
-        let batch_size = batch_size();
-        let sub_batch_size = batch_size / batch_size.ilog2() as usize;
         let opener = ParquetOpener {
             partition_index,
             projection: Arc::from(projection),
-            batch_size: sub_batch_size,
+            batch_size: batch_size(),
             limit: self.base_config.limit,
             predicate: self.predicate.clone(),
             pruning_predicate: self.pruning_predicate.clone(),


### PR DESCRIPTION
related commit: https://github.com/blaze-init/arrow-datafusion/commit/90b13d32d029b95278e5a2317631d870402835be