### PR TITLE
minor fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,6 @@ dependencies = [
  "arrow",
  "blaze-jni-bridge",
  "blaze-serde",
- "chrono",
  "datafusion",
  "datafusion-ext-commons",
  "datafusion-ext-plans",
@@ -468,7 +467,6 @@ version = "0.1.0"
 dependencies = [
  "arrow",
  "base64 0.22.1",
- "chrono",
  "datafusion",
  "datafusion-ext-commons",
  "datafusion-ext-exprs",
@@ -585,9 +583,7 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "wasm-bindgen",
  "windows-targets 0.52.4",
 ]
 
@@ -755,7 +751,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=9d1f7f2fc#9d1f7f2fce162a964d1fc77641e8076043acd77e"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=8cd557f32#8cd557f323b30a40b4f60fe1d316a9f66e23d5f1"
 dependencies = [
  "ahash",
  "arrow",
@@ -804,7 +800,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=9d1f7f2fc#9d1f7f2fce162a964d1fc77641e8076043acd77e"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=8cd557f32#8cd557f323b30a40b4f60fe1d316a9f66e23d5f1"
 dependencies = [
  "ahash",
  "arrow",
@@ -823,7 +819,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=9d1f7f2fc#9d1f7f2fce162a964d1fc77641e8076043acd77e"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=8cd557f32#8cd557f323b30a40b4f60fe1d316a9f66e23d5f1"
 dependencies = [
  "arrow",
  "chrono",
@@ -843,7 +839,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=9d1f7f2fc#9d1f7f2fce162a964d1fc77641e8076043acd77e"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=8cd557f32#8cd557f323b30a40b4f60fe1d316a9f66e23d5f1"
 dependencies = [
  "ahash",
  "arrow",
@@ -961,7 +957,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=9d1f7f2fc#9d1f7f2fce162a964d1fc77641e8076043acd77e"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=8cd557f32#8cd557f323b30a40b4f60fe1d316a9f66e23d5f1"
 dependencies = [
  "arrow",
  "base64 0.21.7",
@@ -975,7 +971,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-array"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=9d1f7f2fc#9d1f7f2fce162a964d1fc77641e8076043acd77e"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=8cd557f32#8cd557f323b30a40b4f60fe1d316a9f66e23d5f1"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -988,7 +984,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=9d1f7f2fc#9d1f7f2fce162a964d1fc77641e8076043acd77e"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=8cd557f32#8cd557f323b30a40b4f60fe1d316a9f66e23d5f1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1005,7 +1001,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=9d1f7f2fc#9d1f7f2fce162a964d1fc77641e8076043acd77e"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=8cd557f32#8cd557f323b30a40b4f60fe1d316a9f66e23d5f1"
 dependencies = [
  "ahash",
  "arrow",
@@ -1040,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=9d1f7f2fc#9d1f7f2fce162a964d1fc77641e8076043acd77e"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=8cd557f32#8cd557f323b30a40b4f60fe1d316a9f66e23d5f1"
 dependencies = [
  "ahash",
  "arrow",
@@ -1070,7 +1066,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "36.0.0"
-source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=9d1f7f2fc#9d1f7f2fce162a964d1fc77641e8076043acd77e"
+source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=8cd557f32#8cd557f323b30a40b4f60fe1d316a9f66e23d5f1"
 dependencies = [
  "arrow",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,15 +63,15 @@ parquet = { version = "50.0.0" }
 serde_json = { version = "1.0.96" }
 
 [patch.crates-io]
-# datafusion: branch=v30-blaze
-datafusion = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "9d1f7f2fc"}
-datafusion-common = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "9d1f7f2fc"}
-datafusion-expr = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "9d1f7f2fc"}
-datafusion-execution = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "9d1f7f2fc"}
-datafusion-optimizer = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "9d1f7f2fc"}
-datafusion-physical-expr = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "9d1f7f2fc"}
+# datafusion: branch=v36-blaze
+datafusion = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "8cd557f32"}
+datafusion-common = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "8cd557f32"}
+datafusion-expr = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "8cd557f32"}
+datafusion-execution = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "8cd557f32"}
+datafusion-optimizer = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "8cd557f32"}
+datafusion-physical-expr = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "8cd557f32"}
 
-# arrow: branch=v45-blaze
+# arrow: branch=v50-blaze
 arrow = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "b1e0762ba4"}
 arrow-arith = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "b1e0762ba4"}
 arrow-array = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "b1e0762ba4"}

--- a/native-engine/blaze-serde/Cargo.toml
+++ b/native-engine/blaze-serde/Cargo.toml
@@ -9,7 +9,6 @@ default = ["prost/no-recursion-limit"]
 [dependencies]
 arrow = { workspace = true }
 base64 = "*"
-chrono = "*"
 datafusion = { workspace = true }
 datafusion-ext-commons = { workspace = true }
 datafusion-ext-exprs = { workspace = true }

--- a/native-engine/blaze-serde/src/from_proto.rs
+++ b/native-engine/blaze-serde/src/from_proto.rs
@@ -24,7 +24,6 @@ use arrow::{
     datatypes::{Field, FieldRef, SchemaRef},
 };
 use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine};
-use chrono::DateTime;
 use datafusion::{
     common::stats::Precision,
     datasource::{
@@ -1095,7 +1094,7 @@ impl TryFrom<&protobuf::PartitionedFile> for PartitionedFile {
             object_meta: ObjectMeta {
                 location: Path::from(format!("/{}", BASE64_URL_SAFE_NO_PAD.encode(&val.path))),
                 size: val.size as usize,
-                last_modified: DateTime::default(),
+                last_modified: Default::default(),
                 e_tag: None,
                 version: None,
             },

--- a/native-engine/blaze/Cargo.toml
+++ b/native-engine/blaze/Cargo.toml
@@ -14,7 +14,6 @@ default = ["tokio/rt-multi-thread"]
 arrow = { workspace = true }
 blaze-jni-bridge = { workspace = true }
 blaze-serde = { workspace = true }
-chrono = "0.4"
 datafusion = { workspace = true }
 datafusion-ext-commons = { workspace = true }
 datafusion-ext-plans = { workspace = true }

--- a/native-engine/datafusion-ext-plans/src/memmgr/spill.rs
+++ b/native-engine/datafusion-ext-plans/src/memmgr/spill.rs
@@ -14,7 +14,7 @@
 
 use std::{
     any::Any,
-    fs::File,
+    fs::{File, OpenOptions},
     io::{BufReader, BufWriter, Cursor, Read, Seek, Write},
     sync::Arc,
     time::Duration,
@@ -88,7 +88,12 @@ impl FileSpill {
             jni_call!(BlazeOnHeapSpillManager(hsm.as_obj()).getDirectWriteSpillToDiskFile()-> JObject)?
                 .as_obj()
                 .into())?;
-            let file = File::create(file_name)?;
+            let file = OpenOptions::new() // create file and open under rw mode
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .read(true)
+                .open(&file_name)?;
             Ok(Self(file, spill_metrics.clone()))
         } else {
             let file = tempfile::tempfile()?;

--- a/native-engine/datafusion-ext-plans/src/project_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/project_exec.rs
@@ -17,10 +17,7 @@
 
 use std::{any::Any, fmt::Formatter, sync::Arc};
 
-use arrow::{
-    datatypes::{Field, Fields, Schema, SchemaRef},
-    record_batch::RecordBatch,
-};
+use arrow::datatypes::{Field, Fields, Schema, SchemaRef};
 use datafusion::{
     common::{Result, Statistics},
     execution::TaskContext,
@@ -31,9 +28,7 @@ use datafusion::{
         DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream,
     },
 };
-use datafusion_ext_commons::{
-    array_size::ArraySize, streams::coalesce_stream::CoalesceInput, suggested_output_batch_mem_size,
-};
+use datafusion_ext_commons::streams::coalesce_stream::CoalesceInput;
 use futures::{stream::once, FutureExt, StreamExt, TryStreamExt};
 use itertools::Itertools;
 
@@ -221,43 +216,16 @@ async fn execute_project_with_filtering(
         InputBatchStatistics::from_metrics_set_and_blaze_conf(&metrics, partition)?,
         input.execute_projected(partition, context.clone(), &projection)?,
     )?;
-    let num_output_cols = output_schema.fields().len();
 
     context.output_with_sender("Project", output_schema, move |sender| async move {
         while let Some(batch) = input.next().await.transpose()? {
             let mut timer = baseline_metrics.elapsed_compute().timer();
+            let output_batch = cached_expr_evaluator.filter_project(&batch)?;
+            drop(batch);
 
-            if batch.num_rows() == 0 {
-                continue;
-            }
-            for batch in split_batch_by_estimated_size(batch, num_output_cols) {
-                let output_batch = cached_expr_evaluator.filter_project(&batch)?;
-                baseline_metrics.record_output(output_batch.num_rows());
-                sender.send(Ok(output_batch), Some(&mut timer)).await;
-            }
+            baseline_metrics.record_output(output_batch.num_rows());
+            sender.send(Ok(output_batch), Some(&mut timer)).await;
         }
         Ok(())
     })
-}
-
-fn split_batch_by_estimated_size(batch: RecordBatch, num_output_cols: usize) -> Vec<RecordBatch> {
-    let target_mem_size = suggested_output_batch_mem_size();
-    let target_num_batches = batch.get_array_mem_size() * 2 * num_output_cols
-        / batch.num_columns().max(1)
-        / target_mem_size;
-
-    if target_num_batches <= 1 {
-        return vec![batch];
-    }
-    let target_num_rows = (batch.num_rows() / target_num_batches.max(1)).max(1);
-
-    let mut batches = vec![];
-    let mut offset = 0;
-
-    while offset < batch.num_rows() {
-        let num_rows = target_num_rows.min(batch.num_rows() - offset);
-        batches.push(batch.slice(offset, num_rows));
-        offset += num_rows;
-    }
-    batches
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/SparkUDFWrapperContext.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/SparkUDFWrapperContext.scala
@@ -42,12 +42,13 @@ case class SparkUDFWrapperContext(serialized: ByteBuffer) extends Logging {
     val bytes = new Array[Byte](serialized.remaining())
     serialized.get(bytes)
     bytes
-  }) match {
-    case (nondeterministic: Nondeterministic, paramsSchema) =>
+  })
+
+  // initialize all nondeterministic children exprs
+  expr.foreach {
+    case nondeterministic: Nondeterministic =>
       nondeterministic.initialize(TaskContext.get.partitionId())
-      (nondeterministic, paramsSchema)
-    case (expr, paramsSchema) =>
-      (expr, paramsSchema)
+    case _ =>
   }
 
   private val dictionaryProvider: DictionaryProvider = new MapDictionaryProvider()


### PR DESCRIPTION
 apply https://github.com/apache/datafusion/pull/10329
 revert "split huge batch into smaller ones during projection (#448)", This reverts commit 7d33df12.
 fix issue "Nondeterministic expression xxx should be initialized before eval".
 fix issue "IO error: Bad file descriptor" while accessing spill file.
 fix jvm coredump by removing chrono dependency for printing logs.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
