### PR TITLE
move spark property "spark.io.compression.codec" to BlazeConf

### DIFF
--- a/native-engine/blaze-jni-bridge/src/jni_bridge.rs
+++ b/native-engine/blaze-jni-bridge/src/jni_bridge.rs
@@ -1158,6 +1158,8 @@ pub struct BlazeConf<'a> {
     pub method_longConf_ret: ReturnType,
     pub method_doubleConf: JStaticMethodID,
     pub method_doubleConf_ret: ReturnType,
+    pub method_stringConf: JStaticMethodID,
+    pub method_stringConf_ret: ReturnType,
 }
 
 impl<'a> BlazeConf<'_> {
@@ -1183,6 +1185,14 @@ impl<'a> BlazeConf<'_> {
                 .get_static_method_id(class, "doubleConf", "(Ljava/lang/String;)D")
                 .unwrap(),
             method_doubleConf_ret: ReturnType::Primitive(Primitive::Double),
+            method_stringConf: env
+                .get_static_method_id(
+                    class,
+                    "stringConf",
+                    "(Ljava/lang/String;)Ljava/lang/String;",
+                )
+                .unwrap(),
+            method_stringConf_ret: ReturnType::Object,
         })
     }
 }

--- a/spark-extension/src/main/java/org/apache/spark/sql/blaze/BlazeConf.java
+++ b/spark-extension/src/main/java/org/apache/spark/sql/blaze/BlazeConf.java
@@ -68,10 +68,12 @@ public enum BlazeConf {
 
     // parqeut enable bloom filter
     PARQUET_ENABLE_BLOOM_FILTER("spark.blaze.parquet.enable.bloomFilter", false),
-    ;
 
-    private String key;
-    private Object defaultValue;
+    // spark io compression codec
+    SPARK_IO_COMPRESSION_CODEC("spark.io.compression.codec", "lz4");
+
+    private final String key;
+    private final Object defaultValue;
 
     BlazeConf(String key, Object defaultValue) {
         this.key = key;
@@ -94,6 +96,10 @@ public enum BlazeConf {
         return conf().getDouble(key, (double) defaultValue);
     }
 
+    public String stringConf() {
+        return conf().get(key, (String) defaultValue);
+    }
+
     public static boolean booleanConf(String confName) {
         return BlazeConf.valueOf(confName).booleanConf();
     }
@@ -108,6 +114,10 @@ public enum BlazeConf {
 
     public static double doubleConf(String confName) {
         return BlazeConf.valueOf(confName).doubleConf();
+    }
+
+    public static String stringConf(String confName) {
+        return BlazeConf.valueOf(confName).stringConf();
     }
 
     private static SparkConf conf() {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.
No issue for this pr
 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1. Support to get String conf value in BlazeConf.scala and conf.rs
2. Avoid to print some warn messages with missing set "spark.io.compression.codec" in ipc reader/writer method
# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
