### PR TITLE
improve shuffle performance

### DIFF
--- a/native-engine/blaze-jni-bridge/src/conf.rs
+++ b/native-engine/blaze-jni-bridge/src/conf.rs
@@ -79,13 +79,13 @@ pub trait DoubleConf {
 
 pub trait StringConf {
     fn key(&self) -> &'static str;
-    fn value(&self) -> Result<&'static str> {
+    fn value(&self) -> Result<String> {
         let key = jni_new_string!(self.key())?;
         let value = jni_get_string!(
             jni_call_static!(BlazeConf.stringConf(key.as_obj()) -> JObject)?
                 .as_obj()
                 .into()
         )?;
-        Ok(Box::leak(value.into_boxed_str()))
+        Ok(value)
     }
 }

--- a/native-engine/datafusion-ext-plans/src/ipc_writer_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/ipc_writer_exec.rs
@@ -149,7 +149,7 @@ pub async fn write_ipc(
             }
         }
 
-        let mut writer = IpcCompressionWriter::new(IpcConsumerWrite(ipc_consumer), true);
+        let mut writer = IpcCompressionWriter::new(IpcConsumerWrite(ipc_consumer));
         while let Some(batch) = input.next().await.transpose()? {
             let _timer = metrics.elapsed_compute().timer();
             writer.write_batch(batch.num_rows(), batch.columns())?;
@@ -157,7 +157,7 @@ pub async fn write_ipc(
         }
 
         let _timer = metrics.elapsed_compute().timer();
-        writer.finish_into_inner()?;
+        writer.finish_current_buf()?;
         Ok(())
     })
 }

--- a/native-engine/datafusion-ext-plans/src/shuffle/rss_single_repartitioner.rs
+++ b/native-engine/datafusion-ext-plans/src/shuffle/rss_single_repartitioner.rs
@@ -32,10 +32,10 @@ pub struct RssSingleShuffleRepartitioner {
 impl RssSingleShuffleRepartitioner {
     pub fn new(rss_partition_writer: GlobalRef) -> Self {
         Self {
-            rss_partition_writer: Arc::new(Mutex::new(IpcCompressionWriter::new(
-                RssWriter::new(rss_partition_writer, 0),
-                true,
-            ))),
+            rss_partition_writer: Arc::new(Mutex::new(IpcCompressionWriter::new(RssWriter::new(
+                rss_partition_writer,
+                0,
+            )))),
         }
     }
 }
@@ -55,7 +55,7 @@ impl ShuffleRepartitioner for RssSingleShuffleRepartitioner {
     }
 
     async fn shuffle_write(&self) -> Result<()> {
-        self.rss_partition_writer.lock().flush()?;
+        self.rss_partition_writer.lock().finish_current_buf()?;
         Ok(())
     }
 }

--- a/native-engine/datafusion-ext-plans/src/shuffle/sort_repartitioner.rs
+++ b/native-engine/datafusion-ext-plans/src/shuffle/sort_repartitioner.rs
@@ -164,10 +164,13 @@ impl ShuffleRepartitioner for SortShuffleRepartitioner {
                     .create(true)
                     .truncate(true)
                     .open(&data_file)?;
+                let mut output_index = OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .open(&index_file)?;
 
                 let offsets = data.write(&mut output_data, &partitioning)?;
-
-                let mut output_index = File::create(&index_file)?;
                 for offset in offsets {
                     output_index.write_all(&(offset as i64).to_le_bytes()[..])?;
                 }


### PR DESCRIPTION
1. reuse compression buffer.
2. prefer coalescing to interleaving when merging same partitions of sorted batches.