### PR TITLE
remove variables from artifacts in pom.xml

### DIFF
--- a/dev/mvn-build-helper/assembly/pom.xml
+++ b/dev/mvn-build-helper/assembly/pom.xml
@@ -20,7 +20,7 @@
     </dependency>
     <dependency>
       <groupId>org.blaze</groupId>
-      <artifactId>spark-extension-shims-${shimPkg}</artifactId>
+      <artifactId>${shimPkg}</artifactId>
       <version>${revision}</version>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <modules>
     <module>spark-extension</module>
-    <module>spark-extension-shims-${shimPkg}</module>
+    <module>${shimPkg}</module>
     <module>dev/mvn-build-helper/assembly</module>
     <module>dev/mvn-build-helper/proto</module>
   </modules>
@@ -264,7 +264,7 @@
       <id>spark303</id>
       <properties>
         <shimName>spark303</shimName>
-        <shimPkg>spark3</shimPkg>
+        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <javaVersion>1.8</javaVersion>
         <scalaVersion>2.12</scalaVersion>
         <scalaLongVersion>2.12.17</scalaLongVersion>
@@ -278,7 +278,7 @@
       <id>spark313</id>
       <properties>
         <shimName>spark313</shimName>
-        <shimPkg>spark3</shimPkg>
+        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <javaVersion>1.8</javaVersion>
         <scalaVersion>2.12</scalaVersion>
         <scalaLongVersion>2.12.15</scalaLongVersion>
@@ -292,7 +292,7 @@
       <id>spark320</id>
       <properties>
         <shimName>spark320</shimName>
-        <shimPkg>spark3</shimPkg>
+        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <javaVersion>1.8</javaVersion>
         <scalaVersion>2.12</scalaVersion>
         <scalaLongVersion>2.12.15</scalaLongVersion>
@@ -306,7 +306,7 @@
       <id>spark324</id>
       <properties>
         <shimName>spark324</shimName>
-        <shimPkg>spark3</shimPkg>
+        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <javaVersion>1.8</javaVersion>
         <scalaVersion>2.12</scalaVersion>
         <scalaLongVersion>2.12.15</scalaLongVersion>
@@ -320,7 +320,7 @@
       <id>spark333</id>
       <properties>
         <shimName>spark333</shimName>
-        <shimPkg>spark3</shimPkg>
+        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <javaVersion>1.8</javaVersion>
         <scalaVersion>2.12</scalaVersion>
         <scalaLongVersion>2.12.15</scalaLongVersion>
@@ -334,7 +334,7 @@
       <id>spark351</id>
       <properties>
         <shimName>spark351</shimName>
-        <shimPkg>spark3</shimPkg>
+        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <javaVersion>1.8</javaVersion>
         <scalaVersion>2.12</scalaVersion>
         <scalaLongVersion>2.12.15</scalaLongVersion>

--- a/spark-extension-shims-spark3/pom.xml
+++ b/spark-extension-shims-spark3/pom.xml
@@ -9,7 +9,7 @@
     <relativePath>../</relativePath>
   </parent>
   <groupId>org.blaze</groupId>
-  <artifactId>spark-extension-shims-${shimPkg}</artifactId>
+  <artifactId>spark-extension-shims-spark3</artifactId>
   <packaging>jar</packaging>
 
   <dependencies>


### PR DESCRIPTION
this fixes the `artifactId with value xxx does not match a valid id pattern` issue.