### PR TITLE
add spark prefix to tpcds.gen.defaultParallel to take affect

### DIFF
--- a/tpcds/datagen/src/main/scala/org/apache/spark/sql/execution/benchmark/TPCDSDatagen.scala
+++ b/tpcds/datagen/src/main/scala/org/apache/spark/sql/execution/benchmark/TPCDSDatagen.scala
@@ -50,7 +50,7 @@ class Tables(sqlContext: SQLContext, scaleFactor: Int) extends Serializable {
     def df(convertToSchema: Boolean, numPartition: Int): DataFrame = {
       val numDefaultPartitions = sparkContext
         .conf
-        .getInt("tpcds.gen.defaultParallel", defaultValue = 1000)
+        .getInt("spark.tpcds.gen.defaultParallel", defaultValue = 1000)
 
       val partitions = if (partitionColumns.isEmpty) numDefaultPartitions else numPartition
       val generatedData = {


### PR DESCRIPTION
# Which issue does this PR close?
`tpcds.gen.defaultParallel` will not take effect beacuse spark only task effect spark prefix

 # Rationale for this change
change `tpcds.gen.defaultParallel` to `spark.tpcds.gen.defaultParallel`

# What changes are included in this PR?
Add spark prefix to tpcds.gen.defaultParallel to make it take affect

# Are there any user-facing changes?
none

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
none