### PR TITLE
[BLAZE-287] Integrate Blaze with Celeborn

### DIFF
--- a/native-engine/datafusion-ext-plans/src/shuffle/buffered_data.rs
+++ b/native-engine/datafusion-ext-plans/src/shuffle/buffered_data.rs
@@ -137,10 +137,11 @@ impl BufferedData {
             return Ok(());
         }
         let mut iter = self.into_sorted_batches(partitioning)?;
+        let mut writer = IpcCompressionWriter::new(RssWriter::new(rss_partition_writer.clone(), 0));
 
         while (iter.cur_part_id() as usize) < partitioning.partition_count() {
             let cur_part_id = iter.cur_part_id();
-            let mut writer = IpcCompressionWriter::new(RssWriter::new(
+            writer.set_output(RssWriter::new(
                 rss_partition_writer.clone(),
                 cur_part_id as usize,
             ));

--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,7 @@
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.0.3</sparkVersion>
+        <celebornVersion>0.5.1</celebornVersion>
       </properties>
     </profile>
 
@@ -291,6 +292,7 @@
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.1.3</sparkVersion>
+        <celebornVersion>0.5.1</celebornVersion>
       </properties>
     </profile>
 
@@ -305,6 +307,7 @@
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.2.4</sparkVersion>
+        <celebornVersion>0.5.1</celebornVersion>
       </properties>
     </profile>
 
@@ -319,6 +322,7 @@
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.3.4</sparkVersion>
+        <celebornVersion>0.5.1</celebornVersion>
       </properties>
     </profile>
 
@@ -333,6 +337,7 @@
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.4.3</sparkVersion>
+        <celebornVersion>0.5.1</celebornVersion>
       </properties>
     </profile>
 
@@ -347,6 +352,7 @@
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.5.3</sparkVersion>
+        <celebornVersion>0.5.1</celebornVersion>
       </properties>
     </profile>
   </profiles>

--- a/spark-extension-shims-spark3/pom.xml
+++ b/spark-extension-shims-spark3/pom.xml
@@ -44,6 +44,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-client-spark-3-shaded_${scalaVersion}</artifactId>
+      <version>${celebornVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-c-data</artifactId>
     </dependency>

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeRssShuffleManagerBase.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeRssShuffleManagerBase.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.execution.blaze.shuffle.BlazeShuffleDependency.isArr
 
 import com.thoughtworks.enableIf
 
-abstract class BlazeRssShuffleManagerBase(conf: SparkConf) extends ShuffleManager with Logging {
+abstract class BlazeRssShuffleManagerBase(_conf: SparkConf) extends ShuffleManager with Logging {
   override def registerShuffle[K, V, C](
       shuffleId: Int,
       dependency: ShuffleDependency[K, V, C]): ShuffleHandle

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleManager.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleManager.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2022 The Blaze Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.blaze.shuffle.celeborn
+
+import org.apache.celeborn.client.ShuffleClient
+import org.apache.celeborn.common.CelebornConf
+import org.apache.commons.lang3.reflect.FieldUtils
+import org.apache.spark.sql.execution.blaze.shuffle.BlazeRssShuffleManagerBase
+import org.apache.spark.SparkConf
+import org.apache.spark.TaskContext
+import org.apache.spark.shuffle.ShuffleBlockResolver
+import org.apache.spark.shuffle.ShuffleReader
+import org.apache.spark.shuffle.ShuffleWriter
+import org.apache.spark.sql.execution.blaze.shuffle.BlazeRssShuffleWriterBase
+import org.apache.spark.ShuffleDependency
+import org.apache.spark.shuffle.ShuffleHandle
+import org.apache.spark.shuffle.ShuffleReadMetricsReporter
+import org.apache.spark.shuffle.ShuffleWriteMetricsReporter
+import org.apache.spark.shuffle.celeborn.SparkShuffleManager
+import org.apache.spark.sql.execution.blaze.shuffle.BlazeRssShuffleReaderBase
+import org.apache.spark.shuffle.celeborn.CelebornShuffleHandle
+import org.apache.spark.shuffle.celeborn.ExecutorShuffleIdTracker
+
+class BlazeCelebornShuffleManager(conf: SparkConf, isDriver: Boolean)
+    extends BlazeRssShuffleManagerBase(conf) {
+  private val celebornShuffleManager: SparkShuffleManager =
+    new SparkShuffleManager(conf, isDriver)
+
+  override def registerShuffle[K, V, C](
+      shuffleId: Int,
+      dependency: ShuffleDependency[K, V, C]): ShuffleHandle = {
+    celebornShuffleManager.registerShuffle(shuffleId, dependency)
+  }
+
+  override def unregisterShuffle(shuffleId: Int): Boolean = {
+    celebornShuffleManager.unregisterShuffle(shuffleId)
+  }
+
+  override def getBlazeRssShuffleReader[K, C](
+      handle: ShuffleHandle,
+      startPartition: Int,
+      endPartition: Int,
+      context: TaskContext,
+      metrics: ShuffleReadMetricsReporter): BlazeRssShuffleReaderBase[K, C] = {
+    this.getBlazeRssShuffleReader(
+      handle,
+      0,
+      Int.MaxValue,
+      startPartition,
+      endPartition,
+      context,
+      metrics)
+  }
+
+  override def getBlazeRssShuffleReader[K, C](
+      handle: ShuffleHandle,
+      startMapIndex: Int,
+      endMapIndex: Int,
+      startPartition: Int,
+      endPartition: Int,
+      context: TaskContext,
+      metrics: ShuffleReadMetricsReporter): BlazeRssShuffleReaderBase[K, C] = {
+
+    val celebornHandle = handle.asInstanceOf[CelebornShuffleHandle[_, _, _]]
+    val celebornConf = FieldUtils
+      .readField(celebornShuffleManager, "celebornConf", true)
+      .asInstanceOf[CelebornConf]
+    val shuffleIdTracker = FieldUtils
+      .readField(celebornShuffleManager, "shuffleIdTracker", true)
+      .asInstanceOf[ExecutorShuffleIdTracker]
+    val reader = new BlazeCelebornShuffleReader(
+      celebornConf,
+      celebornHandle,
+      startPartition,
+      endPartition,
+      startMapIndex = Some(startMapIndex),
+      endMapIndex = Some(endMapIndex),
+      context,
+      metrics,
+      shuffleIdTracker)
+    reader.asInstanceOf[BlazeRssShuffleReaderBase[K, C]]
+  }
+
+  override def getRssShuffleReader[K, C](
+      handle: ShuffleHandle,
+      startPartition: Int,
+      endPartition: Int,
+      context: TaskContext,
+      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
+    celebornShuffleManager.getReader(handle, startPartition, endPartition, context, metrics)
+  }
+
+  override def getRssShuffleReader[K, C](
+      handle: ShuffleHandle,
+      startMapIndex: Int,
+      endMapIndex: Int,
+      startPartition: Int,
+      endPartition: Int,
+      context: TaskContext,
+      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
+    celebornShuffleManager.getReaderForRange(
+      handle,
+      startMapIndex,
+      endMapIndex,
+      startPartition,
+      endPartition,
+      context,
+      metrics)
+  }
+
+  override def getBlazeRssShuffleWriter[K, V](
+      handle: ShuffleHandle,
+      mapId: Long,
+      context: TaskContext,
+      metrics: ShuffleWriteMetricsReporter): BlazeRssShuffleWriterBase[K, V] = {
+
+    // ensure celeborn client is initialized
+    assert(celebornShuffleManager.getWriter(handle, mapId, context, metrics) != null)
+    val shuffleClient = FieldUtils
+      .readField(celebornShuffleManager, "shuffleClient", true)
+      .asInstanceOf[ShuffleClient]
+
+    val celebornHandle = handle.asInstanceOf[CelebornShuffleHandle[_, _, _]]
+    val writer = new BlazeCelebornShuffleWriter(shuffleClient, context, celebornHandle, metrics)
+    writer.asInstanceOf[BlazeRssShuffleWriterBase[K, V]]
+  }
+
+  override def getRssShuffleWriter[K, V](
+      handle: ShuffleHandle,
+      mapId: Long,
+      context: TaskContext,
+      metrics: ShuffleWriteMetricsReporter): ShuffleWriter[K, V] = {
+    celebornShuffleManager.getWriter(handle, mapId, context, metrics)
+  }
+
+  override def shuffleBlockResolver: ShuffleBlockResolver =
+    celebornShuffleManager.shuffleBlockResolver()
+
+  override def stop(): Unit =
+    celebornShuffleManager.stop()
+}
+
+object BlazeCelebornShuffleManager {
+  def getEncodedAttemptNumber(context: TaskContext): Int =
+    (context.stageAttemptNumber << 16) | context.attemptNumber
+}

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleReader.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleReader.scala
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2022 The Blaze Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.blaze.shuffle.celeborn
+
+import java.io.InputStream
+import java.io.IOException
+import java.util
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.collection.JavaConverters._
+
+import org.apache.celeborn.client.ShuffleClient
+import org.apache.celeborn.client.read.CelebornInputStream
+import org.apache.celeborn.client.read.MetricsCallback
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.exception.CelebornIOException
+import org.apache.celeborn.common.exception.PartitionUnRetryAbleException
+import org.apache.celeborn.common.network.client.TransportClient
+import org.apache.celeborn.common.network.protocol.TransportMessage
+import org.apache.celeborn.common.protocol.MessageType
+import org.apache.celeborn.common.protocol.PartitionLocation
+import org.apache.celeborn.common.protocol.PbOpenStreamList
+import org.apache.celeborn.common.protocol.PbOpenStreamListResponse
+import org.apache.celeborn.common.protocol.PbStreamHandler
+import org.apache.celeborn.common.protocol.message.StatusCode
+import org.apache.celeborn.common.util.JavaUtils
+import org.apache.celeborn.common.util.ThreadUtils
+import org.apache.celeborn.common.util.Utils
+import org.apache.celeborn.common.util.ExceptionMaker
+import org.apache.spark.sql.execution.blaze.shuffle.BlazeRssShuffleReaderBase
+import org.apache.spark.TaskContext
+import org.apache.spark.internal.Logging
+import org.apache.spark.shuffle.celeborn.CelebornShuffleHandle
+import org.apache.spark.shuffle.ShuffleReadMetricsReporter
+import org.apache.spark.shuffle.celeborn.CelebornShuffleReader
+import org.apache.spark.shuffle.FetchFailedException
+import org.apache.spark.shuffle.celeborn.CelebornShuffleReader.streamCreatorPool
+import org.apache.spark.shuffle.celeborn.ExecutorShuffleIdTracker
+import org.apache.spark.shuffle.celeborn.SparkUtils
+import org.apache.spark.storage.BlockId
+import org.apache.spark.util.CompletionIterator
+
+class BlazeCelebornShuffleReader[K, C](
+    conf: CelebornConf,
+    handle: CelebornShuffleHandle[K, _, C],
+    startPartition: Int,
+    endPartition: Int,
+    startMapIndex: Option[Int] = None,
+    endMapIndex: Option[Int] = None,
+    context: TaskContext,
+    metrics: ShuffleReadMetricsReporter,
+    shuffleIdTracker: ExecutorShuffleIdTracker)
+    extends BlazeRssShuffleReaderBase[K, C](handle, context)
+    with Logging {
+
+  private val shuffleClient = ShuffleClient.get(
+    handle.appUniqueId,
+    handle.lifecycleManagerHost,
+    handle.lifecycleManagerPort,
+    conf,
+    handle.userIdentifier,
+    handle.extension)
+
+  private val exceptionRef = new AtomicReference[IOException]
+  private val throwsFetchFailure = handle.throwsFetchFailure
+  private val encodedAttemptId = BlazeCelebornShuffleManager.getEncodedAttemptNumber(context)
+
+  override protected def readBlocks(): Iterator[(BlockId, InputStream)] = {
+
+    val shuffleId = SparkUtils.celebornShuffleId(shuffleClient, handle, context, false)
+    shuffleIdTracker.track(handle.shuffleId, shuffleId)
+    logDebug(
+      s"get shuffleId $shuffleId for appShuffleId ${handle.shuffleId} attemptNum ${context.stageAttemptNumber()}")
+
+    // Update the context task metrics for each record read.
+    val metricsCallback = new MetricsCallback {
+      override def incBytesRead(bytesWritten: Long): Unit = {
+        metrics.incRemoteBytesRead(bytesWritten)
+        metrics.incRemoteBlocksFetched(1)
+      }
+
+      override def incReadTime(time: Long): Unit =
+        metrics.incFetchWaitTime(time)
+    }
+
+    if (streamCreatorPool == null) {
+      CelebornShuffleReader.synchronized {
+        if (streamCreatorPool == null) {
+          streamCreatorPool = ThreadUtils.newDaemonCachedThreadPool(
+            "celeborn-create-stream-thread",
+            conf.readStreamCreatorPoolThreads,
+            60)
+        }
+      }
+    }
+
+    val startTime = System.currentTimeMillis()
+    val fetchTimeoutMs = conf.clientFetchTimeoutMs
+    val localFetchEnabled = conf.enableReadLocalShuffleFile
+    val localHostAddress = Utils.localHostName(conf)
+    val shuffleKey = Utils.makeShuffleKey(handle.appUniqueId, shuffleId)
+    // startPartition is irrelevant
+    val fileGroups = shuffleClient.updateFileGroup(shuffleId, startPartition)
+    // host-port -> (TransportClient, PartitionLocation Array, PbOpenStreamList)
+    val workerRequestMap = new util.HashMap[
+      String,
+      (TransportClient, util.ArrayList[PartitionLocation], PbOpenStreamList.Builder)]()
+
+    var partCnt = 0
+
+    (startPartition until endPartition).foreach { partitionId =>
+      if (fileGroups.partitionGroups.containsKey(partitionId)) {
+        fileGroups.partitionGroups.get(partitionId).asScala.foreach { location =>
+          partCnt += 1
+          val hostPort = location.hostAndFetchPort
+          if (!workerRequestMap.containsKey(hostPort)) {
+            val client = shuffleClient
+              .getDataClientFactory()
+              .createClient(location.getHost, location.getFetchPort)
+            val pbOpenStreamList = PbOpenStreamList.newBuilder()
+            pbOpenStreamList.setShuffleKey(shuffleKey)
+            workerRequestMap
+              .put(hostPort, (client, new util.ArrayList[PartitionLocation], pbOpenStreamList))
+          }
+          val (_, locArr, pbOpenStreamListBuilder) = workerRequestMap.get(hostPort)
+
+          locArr.add(location)
+          pbOpenStreamListBuilder
+            .addFileName(location.getFileName)
+            .addStartIndex(startMapIndex.getOrElse(0))
+            .addEndIndex(endMapIndex.getOrElse(Int.MaxValue))
+          pbOpenStreamListBuilder.addReadLocalShuffle(
+            localFetchEnabled && location.getHost.equals(localHostAddress))
+        }
+      }
+    }
+
+    val locationStreamHandlerMap: ConcurrentHashMap[PartitionLocation, PbStreamHandler] =
+      JavaUtils.newConcurrentHashMap()
+
+    val futures = workerRequestMap
+      .values()
+      .asScala
+      .map { entry =>
+        streamCreatorPool.submit(new Runnable {
+          override def run(): Unit = {
+            val (client, locArr, pbOpenStreamListBuilder) = entry
+            val msg = new TransportMessage(
+              MessageType.BATCH_OPEN_STREAM,
+              pbOpenStreamListBuilder.build().toByteArray)
+            val pbOpenStreamListResponse =
+              try {
+                val response = client.sendRpcSync(msg.toByteBuffer, fetchTimeoutMs)
+                TransportMessage
+                  .fromByteBuffer(response)
+                  .getParsedPayload[PbOpenStreamListResponse]
+              } catch {
+                case _: Exception => null
+              }
+            if (pbOpenStreamListResponse != null) {
+              0 until locArr.size() foreach { idx =>
+                val streamHandlerOpt = pbOpenStreamListResponse.getStreamHandlerOptList.get(idx)
+                if (streamHandlerOpt.getStatus == StatusCode.SUCCESS.getValue) {
+                  locationStreamHandlerMap.put(locArr.get(idx), streamHandlerOpt.getStreamHandler)
+                }
+              }
+            }
+          }
+        })
+      }
+      .toList
+    // wait for all futures to complete
+    futures.foreach(f => f.get())
+    val end = System.currentTimeMillis()
+    logInfo(s"BatchOpenStream for $partCnt cost ${end - startTime}ms")
+
+    val streams = new ConcurrentHashMap[Integer, CelebornInputStream]()
+
+    def createInputStream(partitionId: Int): Unit = {
+      val locations =
+        if (fileGroups.partitionGroups.containsKey(partitionId)) {
+          new util.ArrayList(fileGroups.partitionGroups.get(partitionId))
+        } else new util.ArrayList[PartitionLocation]()
+      val streamHandlers =
+        if (locations != null) {
+          val streamHandlerArr = new util.ArrayList[PbStreamHandler](locations.size())
+          locations.asScala.foreach { loc =>
+            streamHandlerArr.add(locationStreamHandlerMap.get(loc))
+          }
+          streamHandlerArr
+        } else null
+      if (exceptionRef.get() == null) {
+        try {
+          val inputStream = shuffleClient.readPartition(
+            shuffleId,
+            handle.shuffleId,
+            partitionId,
+            encodedAttemptId,
+            startMapIndex.getOrElse(0),
+            endMapIndex.getOrElse(Int.MaxValue),
+            if (throwsFetchFailure) {
+              new ExceptionMaker() {
+                override def makeFetchFailureException(
+                    appShuffleId: Int,
+                    shuffleId: Int,
+                    partitionId: Int,
+                    e: Exception): Exception = new FetchFailedException(
+                  null,
+                  appShuffleId,
+                  -1,
+                  -1,
+                  partitionId,
+                  s"Celeborn FetchFailure with shuffle id $appShuffleId/$shuffleId",
+                  e)
+              }
+            } else {
+              null
+            },
+            locations,
+            streamHandlers,
+            fileGroups.mapAttempts,
+            metricsCallback)
+          streams.put(partitionId, inputStream)
+        } catch {
+          case e: IOException =>
+            logError(s"Exception caught when readPartition $partitionId!", e)
+            exceptionRef.compareAndSet(null, e)
+          case e: Throwable =>
+            logError(s"Non IOException caught when readPartition $partitionId!", e)
+            exceptionRef.compareAndSet(null, new CelebornIOException(e))
+        }
+      }
+    }
+
+    val inputStreamCreationWindow = conf.clientInputStreamCreationWindow
+    (startPartition until Math.min(startPartition + inputStreamCreationWindow, endPartition))
+      .foreach(partitionId => {
+        streamCreatorPool.submit(new Runnable {
+          override def run(): Unit = {
+            createInputStream(partitionId)
+          }
+        })
+      })
+
+    val recordIter = (startPartition until endPartition).iterator
+      .map(partitionId => {
+        if (handle.numMappers > 0) {
+          val startFetchWait = System.nanoTime()
+          var inputStream: CelebornInputStream = streams.get(partitionId)
+          while (inputStream == null) {
+            if (exceptionRef.get() != null) {
+              exceptionRef.get() match {
+                case ce @ (_: CelebornIOException | _: PartitionUnRetryAbleException) =>
+                  if (throwsFetchFailure &&
+                    shuffleClient.reportShuffleFetchFailure(handle.shuffleId, shuffleId)) {
+                    throw new FetchFailedException(
+                      null,
+                      handle.shuffleId,
+                      -1,
+                      -1,
+                      partitionId,
+                      SparkUtils.FETCH_FAILURE_ERROR_MSG + handle.shuffleId + "/" + shuffleId,
+                      ce)
+                  } else
+                    throw ce
+                case e => throw e
+              }
+            }
+            log.info("inputStream is null, sleeping...")
+            Thread.sleep(50)
+            inputStream = streams.get(partitionId)
+          }
+          metricsCallback.incReadTime(
+            TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startFetchWait))
+          // ensure inputStream is closed when task completes
+          context.addTaskCompletionListener[Unit](_ => inputStream.close())
+
+          // Advance the input creation window
+          if (partitionId + inputStreamCreationWindow < endPartition) {
+            streamCreatorPool.submit(new Runnable {
+              override def run(): Unit = {
+                createInputStream(partitionId + inputStreamCreationWindow)
+              }
+            })
+          }
+
+          (partitionId, inputStream)
+        } else {
+          (partitionId, CelebornInputStream.empty())
+        }
+      })
+      .filter { case (_, inputStream) =>
+        inputStream != CelebornInputStream.empty()
+      }
+
+    CompletionIterator[(BlockId, InputStream), Iterator[(BlockId, InputStream)]](
+      recordIter.map(block => (null, block._2)), // blockId is not used
+      () => context.taskMetrics().mergeShuffleReadMetrics())
+  }
+}

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleWriter.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleWriter.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 The Blaze Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.blaze.shuffle.celeborn
+
+import org.apache.celeborn.client.ShuffleClient
+import org.apache.spark.shuffle.ShuffleHandle
+import org.apache.spark.shuffle.ShuffleWriteMetricsReporter
+import org.apache.spark.shuffle.celeborn.CelebornShuffleHandle
+import org.apache.spark.sql.execution.blaze.shuffle.BlazeRssShuffleWriterBase
+import org.apache.spark.sql.execution.blaze.shuffle.RssPartitionWriterBase
+import org.apache.spark.TaskContext
+
+import com.thoughtworks.enableIf
+
+class BlazeCelebornShuffleWriter[K, C](
+    shuffleClient: ShuffleClient,
+    taskContext: TaskContext,
+    handle: CelebornShuffleHandle[K, _, C],
+    metrics: ShuffleWriteMetricsReporter)
+    extends BlazeRssShuffleWriterBase[K, C](metrics) {
+
+  private val numMappers = handle.numMappers
+  private val encodedAttemptId = BlazeCelebornShuffleManager.getEncodedAttemptNumber(taskContext)
+
+  override def getRssPartitionWriter(
+      _handle: ShuffleHandle,
+      _mapId: Int,
+      metrics: ShuffleWriteMetricsReporter,
+      numPartitions: Int): RssPartitionWriterBase = {
+
+    new CelebornPartitionWriter(
+      shuffleClient,
+      handle.shuffleId,
+      encodedAttemptId,
+      numMappers,
+      numPartitions,
+      metrics)
+  }
+
+  @enableIf(
+    Seq("spark-3.2", "spark-3.3", "spark-3.4", "spark-3.5").contains(
+      System.getProperty("blaze.shim")))
+  override def getPartitionLengths(): Array[Long] = partitionLengths
+
+}

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/CelebornPartitionWriter.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/CelebornPartitionWriter.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 The Blaze Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.blaze.shuffle.celeborn
+
+import java.nio.ByteBuffer
+
+import org.apache.spark.sql.execution.blaze.shuffle.RssPartitionWriterBase
+import org.apache.celeborn.client.ShuffleClient
+import org.apache.spark.internal.Logging
+import org.apache.spark.TaskContext
+import org.apache.spark.shuffle.ShuffleWriteMetricsReporter
+
+class CelebornPartitionWriter(
+    shuffleClient: ShuffleClient,
+    shuffleId: Int,
+    encodedAttemptId: Int,
+    numMappers: Int,
+    numPartitions: Int,
+    metrics: ShuffleWriteMetricsReporter)
+    extends RssPartitionWriterBase
+    with Logging {
+
+  private val mapStatusLengths: Array[Long] = Array.fill(numPartitions)(0L)
+  private val mapId = TaskContext.get.partitionId
+
+  override def write(partitionId: Int, buffer: ByteBuffer): Unit = {
+    val numBytes = buffer.limit()
+    val bytes = new Array[Byte](numBytes)
+    buffer.get(bytes)
+
+    val bytesWritten = shuffleClient.pushData(
+      shuffleId,
+      mapId,
+      encodedAttemptId,
+      partitionId,
+      bytes,
+      0,
+      numBytes,
+      numMappers,
+      numPartitions)
+    metrics.incBytesWritten(bytesWritten)
+    mapStatusLengths(partitionId) += bytesWritten
+  }
+
+  override def flush(): Unit = {}
+
+  override def close(): Unit = {
+    shuffleClient.mapperEnd(shuffleId, mapId, encodedAttemptId, numMappers)
+  }
+
+  override def getPartitionLengthMap: Array[Long] =
+    mapStatusLengths
+
+  override def stop(): Unit = {
+    shuffleClient.cleanup(shuffleId, mapId, encodedAttemptId)
+  }
+}

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/RssPartitionWriterBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/RssPartitionWriterBase.scala
@@ -22,4 +22,5 @@ trait RssPartitionWriterBase {
   def flush(): Unit
   def close(): Unit
   def getPartitionLengthMap: Array[Long]
+  def stop(): Unit
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #287 .

# What changes are included in this PR?
[Celeborn](https://github.com/apache/celeborn)  is an intermediate data service for Big Data compute engines (i.e. ETL, OLAP and Streaming engines) to boost performance, stability, and flexibility. Intermediate data typically include shuffle and spilled data. Integrate Blaze with Celeborn(0.5.1 latest stable version), will benefit Blaze + Spark in terms of shuffle performance and stability, allowing for a greater focus on optimizing computations. 

# Are there any user-facing changes?
No

# Testing
Testing Blaze + Spark3.4+ Celeborn 0.5.1 use Some TPCDS queries with Flowing Configurations
- spark.shuffle.manager org.apache.spark.sql.execution.blaze.shuffle.celeborn.BlazeCelebornShuffleManager
- spark.celeborn.master.endpoints master-1-1:9097
- spark.blaze.enable true
- spark.sql.extensions org.apache.spark.sql.blaze.BlazeSparkSessionExtension
- spark.memory.offHeap.enabled false


