### PR TITLE
fix Hashaggregate convert job throw ScalaReflectionException

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
@@ -615,7 +615,7 @@ object BlazeConverters extends Logging {
                   case "aggregateExpressions" => transformedAggregateExprs
                   case "groupingExpressions" => transformedGroupingExprs
                   case "child" => convertProjectExec(ProjectExec(projections, exec.child))
-                  case _ => mirror.reflectField(param.asTerm).get
+                  case _ => mirror.reflectField(typeOf[HashAggregateExec].decl(TermName(param.name.toString)).asTerm).get
                 }
               }
               mirror.reflectMethod(copyMethod)(args: _*).asInstanceOf[HashAggregateExec]


### PR DESCRIPTION
WARN BlazeConverters: Error converting exec: HashAggregateExec: expected a member of class HashAggregateExec, you provided value org.apache.spark.sql.execution.aggregate.HashAggregateExec.requiredChildDistributionExpressions scala.ScalaReflectionException: expected a member of class HashAggregateExec, you provided value org.apache.spark.sql.execution.aggregate.HashAggregateExec.requiredChildDistributionExpressions
        at scala.reflect.runtime.JavaMirrors$JavaMirror.scala$reflect$runtime$JavaMirrors$JavaMirror$$abort(JavaMirrors.scala:155)
        at scala.reflect.runtime.JavaMirrors$JavaMirror.ErrorNotMember(JavaMirrors.scala:161)
        at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$checkMemberOf$1(JavaMirrors.scala:256)
        at scala.reflect.runtime.JavaMirrors$JavaMirror.scala$reflect$runtime$JavaMirrors$JavaMirror$$checkMemberOf(JavaMirrors.scala:246)
        at scala.reflect.runtime.JavaMirrors$JavaMirror$JavaInstanceMirror.reflectField(JavaMirrors.scala:278)
        at scala.reflect.runtime.JavaMirrors$JavaMirror$JavaInstanceMirror.reflectField(JavaMirrors.scala:275)
        at org.apache.spark.sql.blaze.BlazeConverters$.$anonfun$convertHashAggregateExec$1(BlazeConverters.scala:616)
        at scala.collection.immutable.List.map(List.scala:293)
        at org.apache.spark.sql.blaze.BlazeConverters$.convertHashAggregateExec(BlazeConverters.scala:611)
        at org.apache.spark.sql.blaze.BlazeConverters$.$anonfun$convertSparkPlan$15(BlazeConverters.scala:177)
        at org.apache.spark.sql.blaze.BlazeConverters$.tryConvert(BlazeConverters.scala:243)

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #636.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
