### PR TITLE
[BLAZE-573][FOLLOWUP] Bump Spark from 3.4.3 to 3.4.4

### DIFF
--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -38,7 +38,7 @@ jobs:
     uses: ./.github/workflows/tpcds-reusable.yml
     with:
       sparkver: spark-3.4
-      sparkurl: https://archive.apache.org/dist/spark/spark-3.4.3/spark-3.4.3-bin-hadoop3.tgz
+      sparkurl: https://archive.apache.org/dist/spark/spark-3.4.4/spark-3.4.4-bin-hadoop3.tgz
 
   test-spark-35:
     name: Test spark-3.5

--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
         <scalaLongVersion>2.12.15</scalaLongVersion>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
-        <sparkVersion>3.4.3</sparkVersion>
+        <sparkVersion>3.4.4</sparkVersion>
         <celebornVersion>0.5.1</celebornVersion>
       </properties>
     </profile>


### PR DESCRIPTION
# Which issue does this PR close?

Closes #573.

Spark 3.4.4 has already released, of which release note refers to [Spark 3.4.4 released](https://spark.apache.org/news/spark-3-4-4-released.html).

# What changes are included in this PR?

Bump Spark from 3.4.3 to 3.4.4.

# Are there any user-facing changes?

No.