### PR TITLE
[BLAZE-664] Bump Celeborn version from 0.5.1 to 0.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.0.3</sparkVersion>
-        <celebornVersion>0.5.1</celebornVersion>
+        <celebornVersion>0.5.2</celebornVersion>
       </properties>
     </profile>
 
@@ -287,7 +287,7 @@
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.1.3</sparkVersion>
-        <celebornVersion>0.5.1</celebornVersion>
+        <celebornVersion>0.5.2</celebornVersion>
       </properties>
     </profile>
 
@@ -302,7 +302,7 @@
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.2.4</sparkVersion>
-        <celebornVersion>0.5.1</celebornVersion>
+        <celebornVersion>0.5.2</celebornVersion>
       </properties>
     </profile>
 
@@ -317,7 +317,7 @@
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.3.4</sparkVersion>
-        <celebornVersion>0.5.1</celebornVersion>
+        <celebornVersion>0.5.2</celebornVersion>
       </properties>
     </profile>
 
@@ -332,7 +332,7 @@
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.4.4</sparkVersion>
-        <celebornVersion>0.5.1</celebornVersion>
+        <celebornVersion>0.5.2</celebornVersion>
       </properties>
     </profile>
 
@@ -347,7 +347,7 @@
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.5.3</sparkVersion>
-        <celebornVersion>0.5.1</celebornVersion>
+        <celebornVersion>0.5.2</celebornVersion>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
# Which issue does this PR close?

Closes #664.

 # Rationale for this change

Celeborn 0.5.2 is released, of which release note refers to [release_note_0.5.2](https://celeborn.apache.org/community/release_notes/release_note_0.5.2/).

# What changes are included in this PR?

Bump Celeborn version from 0.5.1 to 0.5.2 including bump the following commit:

- https://github.com/apache/celeborn/pull/2854
- https://github.com/apache/celeborn/pull/2894

# Are there any user-facing changes?

No.