### PR TITLE
[MINOR] Avoid NPE when native lib is not found

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeCallNativeWrapper.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeCallNativeWrapper.scala
@@ -199,10 +199,11 @@ object BlazeCallNativeWrapper extends Logging {
       val tempFile = File.createTempFile("libblaze-", ".tmp")
       tempFile.deleteOnExit()
 
-      Utils.tryWithResource(classLoader.getResourceAsStream(libName)) { is =>
+      Utils.tryWithResource {
+        val is = classLoader.getResourceAsStream(libName)
         assert(is != null, s"cannot load $libName")
-        Files.copy(is, tempFile.toPath, StandardCopyOption.REPLACE_EXISTING)
-      }
+        is
+      }(Files.copy(_, tempFile.toPath, StandardCopyOption.REPLACE_EXISTING))
       System.load(tempFile.getAbsolutePath)
 
     } catch {


### PR DESCRIPTION
# Which issue does this PR close?

minor fix, `createResource` should not return null

https://github.com/apache/spark/blob/4eed18455332164e63e58bbd8e828ebb9639143c/common/utils/src/main/scala/org/apache/spark/util/SparkErrorUtils.scala#L46-L49

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
