### PR TITLE
Create RecordBatch with num_rows option to avoid bhj error caused by empty output_schema

### DIFF
--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeQuerySuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeQuerySuite.scala
@@ -12,4 +12,13 @@ class BlazeQuerySuite extends org.apache.spark.sql.QueryTest with BaseBlazeSQLSu
     }
   }
 
+  test("empty output in bnlj") {
+    withTable("t1", "t2") {
+      sql("create table t1 using parquet as select 1 as c1, 2 as c2")
+      sql("create table t2 using parquet as select 1 as c1, 3 as c3")
+      val df = sql("select 1 from t1 left join t2")
+      checkAnswer(df, Seq(Row(1)))
+    }
+  }
+
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeBroadcastJoinBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeBroadcastJoinBase.scala
@@ -109,7 +109,7 @@ abstract class NativeBroadcastJoinBase(
   }
 
   // check whether native converting is supported
-  assert(nativeSchema.getColumnsCount > 0, "Native schema of BroadcastJoin cannot be empty.")
+  nativeSchema
   nativeJoinType
   nativeJoinOn
   nativeBroadcastSide

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeBroadcastJoinBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeBroadcastJoinBase.scala
@@ -109,7 +109,7 @@ abstract class NativeBroadcastJoinBase(
   }
 
   // check whether native converting is supported
-  nativeSchema
+  assert(nativeSchema.getColumnsCount > 0, "Native schema of BroadcastJoin cannot be empty.")
   nativeJoinType
   nativeJoinOn
   nativeBroadcastSide


### PR DESCRIPTION
# Which issue does this PR close?

Closes #682

# Rationale for this change

Native schema of BroadcastJoin cannot be empty.

https://github.com/kwai/blaze/blob/b662097e7379c4a5912706d58562658b02274335/native-engine/datafusion-ext-plans/src/joins/bhj/full_join.rs#L126




# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
