### PR TITLE
Automatically use the protoc version downloaded by the maven plugin

### DIFF
--- a/dev/mvn-build-helper/proto/pom.xml
+++ b/dev/mvn-build-helper/proto/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.21.9</version>
+      <version>${protobufVersion}</version>
     </dependency>
   </dependencies>
 

--- a/native-engine/blaze-serde/build.rs
+++ b/native-engine/blaze-serde/build.rs
@@ -12,11 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{fs, path::PathBuf};
+
 fn main() -> Result<(), String> {
     // for use in docker build where file changes can be wonky
     println!("cargo:rerun-if-env-changed=FORCE_REBUILD");
 
     println!("cargo:rerun-if-changed=proto/blaze.proto");
-    tonic_build::compile_protos("proto/blaze.proto")
+
+    let mut prost_build = tonic_build::Config::new();
+    // protobuf-maven-plugin download the protoc executable in the target directory
+    let protoc_dir_path = "../../dev/mvn-build-helper/proto/target/protoc-plugins";
+    let mut protoc_file: Option<PathBuf> = None;
+    if let Ok(entries) = fs::read_dir(protoc_dir_path) {
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+            if path.is_file()
+                && path
+                    .file_name()
+                    .map(|f| f.to_string_lossy().starts_with("protoc"))
+                    .unwrap_or(false)
+            {
+                protoc_file = Some(path);
+                break;
+            }
+        }
+    }
+    if let Some(path) = protoc_file {
+        eprintln!("Using protoc executable: {:?}", path);
+        prost_build.protoc_executable(path);
+    }
+    prost_build
+        .compile_protos(&["proto/blaze.proto"], &["proto"])
         .map_err(|e| format!("protobuf compilation failed: {}", e))
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change
Simplify protoc installation and configuration.

# What changes are included in this PR?
Try using the protoc version downloaded by protobuf-maven-plugin.

# Are there any user-facing changes?
No