### PR TITLE
[BLAZE-706] Fix year/month/day functions data type

### DIFF
--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeQuerySuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeQuerySuite.scala
@@ -37,4 +37,20 @@ class BlazeQuerySuite extends org.apache.spark.sql.QueryTest with BaseBlazeSQLSu
     }
   }
 
+  test("test filter with year function") {
+    withTable("t1") {
+      sql("create table t1 using parquet as select '2024-12-18' as event_time")
+      checkAnswer(
+        sql(
+          """
+            |select year, count(*)
+            |from (select event_time, year(event_time) as year from t1) t
+            |where year <= 2024
+            |group by year
+            |""".stripMargin),
+        Seq(Row(2024, 1))
+      )
+    }
+  }
+
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeConverters.scala
@@ -873,9 +873,9 @@ object NativeConverters extends Logging {
       case XxHash64(children, 42L) =>
         buildExtScalarFunction("XxHash64", children, LongType)
 
-      case Year(child) => buildExtScalarFunction("Year", child :: Nil, DateType)
-      case Month(child) => buildExtScalarFunction("Month", child :: Nil, DateType)
-      case DayOfMonth(child) => buildExtScalarFunction("Day", child :: Nil, DateType)
+      case Year(child) => buildExtScalarFunction("Year", child :: Nil, IntegerType)
+      case Month(child) => buildExtScalarFunction("Month", child :: Nil, IntegerType)
+      case DayOfMonth(child) => buildExtScalarFunction("Day", child :: Nil, IntegerType)
 
       // startswith is converted to scalar function in pruning-expr mode
       case StartsWith(expr, Literal(prefix, StringType)) if isPruningExpr =>


### PR DESCRIPTION
# Which issue does this PR close?

Closes #706

# Rationale for this change

Fix year/month/day functions data type

# Are there any user-facing changes?

