### PR TITLE
[BLAZE-704] Specify name for spark ext function

### DIFF
--- a/native-engine/blaze-serde/src/from_proto.rs
+++ b/native-engine/blaze-serde/src/from_proto.rs
@@ -1000,9 +1000,10 @@ fn try_parse_physical_expr(
                     .collect::<Result<Vec<_>, _>>()?;
 
                 let scalar_udf = if scalar_function == protobuf::ScalarFunction::SparkExtFunctions {
-                    let fun = datafusion_ext_functions::create_spark_ext_function(&e.name)?;
+                    let fun_name = &e.name;
+                    let fun = datafusion_ext_functions::create_spark_ext_function(fun_name)?;
                     Arc::new(create_udf(
-                        "spark_ext_function",
+                        &format!("spark_ext_function_{}", fun_name),
                         args.iter()
                             .map(|e| e.data_type(input_schema))
                             .collect::<Result<Vec<_>, _>>()?,

--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeQuerySuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeQuerySuite.scala
@@ -56,7 +56,6 @@ class BlazeQuerySuite extends org.apache.spark.sql.QueryTest with BaseBlazeSQLSu
   test("test select multiple spark ext functions with the same signature") {
     withTable("t1") {
       sql("create table t1 using parquet as select '2024-12-18' as event_time")
-      sql("select year(event_time), month(event_time) from t1").show()
       checkAnswer(
         sql("select year(event_time), month(event_time) from t1"),
         Seq(Row(2024, 12))

--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeQuerySuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeQuerySuite.scala
@@ -53,4 +53,14 @@ class BlazeQuerySuite extends org.apache.spark.sql.QueryTest with BaseBlazeSQLSu
     }
   }
 
+  test("test select multiple spark ext functions with the same signature") {
+    withTable("t1") {
+      sql("create table t1 using parquet as select '2024-12-18' as event_time")
+      sql("select year(event_time), month(event_time) from t1").show()
+      checkAnswer(
+        sql("select year(event_time), month(event_time) from t1"),
+        Seq(Row(2024, 12))
+      )
+    }
+  }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #704.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Datafusion determines whether ScalarUDFImpl is the same based on function name and signature.

https://github.com/apache/datafusion/blob/63ce4865896b906ca34fcbf85fdc55bff3080c30/datafusion/expr/src/udf.rs#L692-L694

# What changes are included in this PR?

Specify name for spark ext function

# Are there any user-facing changes?
