### PR TITLE
[BLAZE-287][FOLLOWUP] BlazeCelebornShuffleWriter should use mapped shuffle id for rerunning stage of fetch failure

### DIFF
--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleManager.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleManager.scala
@@ -134,7 +134,10 @@ class BlazeCelebornShuffleManager(conf: SparkConf, isDriver: Boolean)
       .asInstanceOf[ShuffleClient]
 
     val celebornHandle = handle.asInstanceOf[CelebornShuffleHandle[_, _, _]]
-    val writer = new BlazeCelebornShuffleWriter(shuffleClient, context, celebornHandle, metrics)
+    val shuffleIdTracker = FieldUtils
+      .readField(celebornShuffleManager, "shuffleIdTracker", true)
+      .asInstanceOf[ExecutorShuffleIdTracker]
+    val writer = new BlazeCelebornShuffleWriter(shuffleClient, context, celebornHandle, metrics, shuffleIdTracker)
     writer.asInstanceOf[BlazeRssShuffleWriterBase[K, V]]
   }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #287.

# Rationale for this change

When `CelebornShuffleHandle#throwsFetchFailure` returns true, `BlazeCelebornShuffleWriter` should use mapped shuffle id via `SparkUtils#celebornShuffleId` to avoid using wrong shuffle id.

# What changes are included in this PR?

`BlazeCelebornShuffleWriter` uses mapped shuffle id` via `SparkUtils#celebornShuffleId` for throwing fetch failure.

# Are there any user-facing changes?

No.