### PR TITLE
[BLAZE-707][FOLLOWUP] NativePaimonTableScanExec should use shimed PartitionedFile and min partition number

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/Shims.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/Shims.scala
@@ -46,7 +46,9 @@ import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.hive.execution.InsertIntoHiveTable
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.storage.FileSegment
 
@@ -237,6 +239,14 @@ abstract class Shims {
       nativeExpr: pb.PhysicalExprNode,
       dataType: DataType,
       nullable: Boolean): Expression
+
+  def getPartitionedFile(
+      partitionValues: InternalRow,
+      filePath: String,
+      offset: Long,
+      size: Long): PartitionedFile
+
+  def getMinPartitionNum(sparkSession: SparkSession): Int
 
   def postTransform(plan: SparkPlan, sc: SparkContext): Unit = {}
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #707.

 # Rationale for this change

`PartitionedFile` has different constructors among different Spark versions. Meanwhile, the min partition number of max splits is also different for different Spark versions. `NativePaimonTableScanExec` should use shimed `PartitionedFile` and min partition number for compilation error as follows:

- spark-3.0

```
Error: ] /home/runner/work/blaze/blaze/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/blaze/plan/NativePaimonTableScanExec.scala:232: value filesMinPartitionNum is not a member of org.apache.spark.sql.internal.SQLConf

```

- spark-3.4, spark-3.5

```
Error: ] /home/runner/work/blaze/blaze/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/blaze/plan/NativePaimonTableScanExec.scala:219: type mismatch;
 found   : String
 required: org.apache.spark.paths.SparkPath
Error: ] /home/runner/work/blaze/blaze/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/blaze/plan/NativePaimonTableScanExec.scala:222: type mismatch;
 found   : String
 required: org.apache.spark.paths.SparkPath
```

# What changes are included in this PR?

`NativePaimonTableScanExec` uses shimed `PartitionedFile` and min partition number to fix compilation error.

# Are there any user-facing changes?

No.