### PR TITLE
[BLAZE-725] Bump Spark from 3.5.3 to 3.5.4

### DIFF
--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -47,4 +47,4 @@ jobs:
     uses: ./.github/workflows/tpcds-reusable.yml
     with:
       sparkver: spark-3.5
-      sparkurl: https://archive.apache.org/dist/spark/spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz
+      sparkurl: https://archive.apache.org/dist/spark/spark-3.5.4/spark-3.5.4-bin-hadoop3.tgz

--- a/pom.xml
+++ b/pom.xml
@@ -380,7 +380,7 @@
         <scalaLongVersion>2.12.15</scalaLongVersion>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
-        <sparkVersion>3.5.3</sparkVersion>
+        <sparkVersion>3.5.4</sparkVersion>
         <celebornVersion>0.5.2</celebornVersion>
       </properties>
     </profile>


### PR DESCRIPTION
# Which issue does this PR close?

Closes #725.

 # Rationale for this change

Spark 3.5.4 has been announced to release: [Spark 3.5.4 released](https://spark.apache.org/news/spark-3-5-4-released.html). The profile spark-3.5 could bump Spark from 3.5.3 to 3.5.4.

# What changes are included in this PR?

Bump Spark from 3.5.3 to 3.5.4.

# Are there any user-facing changes?

No.