### PR TITLE
[BLAZE-744] Bump Celeborn version from 0.5.2 to 0.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <arrowVersion>16.0.0</arrowVersion>
     <protobufVersion>3.21.9</protobufVersion>
     <paimonVersion>0.9.0</paimonVersion>
+    <celebornVersion>0.5.3</celebornVersion>
   </properties>
 
   <dependencyManagement>
@@ -306,7 +307,6 @@
         <scalaTestVersion>3.0.8</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.0.3</sparkVersion>
-        <celebornVersion>0.5.2</celebornVersion>
       </properties>
     </profile>
 
@@ -321,7 +321,6 @@
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.1.3</sparkVersion>
-        <celebornVersion>0.5.2</celebornVersion>
       </properties>
     </profile>
 
@@ -336,7 +335,6 @@
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.2.4</sparkVersion>
-        <celebornVersion>0.5.2</celebornVersion>
       </properties>
     </profile>
 
@@ -351,7 +349,6 @@
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.3.4</sparkVersion>
-        <celebornVersion>0.5.2</celebornVersion>
       </properties>
     </profile>
 
@@ -366,7 +363,6 @@
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.4.4</sparkVersion>
-        <celebornVersion>0.5.2</celebornVersion>
       </properties>
     </profile>
 
@@ -381,7 +377,6 @@
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.5.4</sparkVersion>
-        <celebornVersion>0.5.2</celebornVersion>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
# Which issue does this PR close?

Closes #744.

 # Rationale for this change

Celeborn 0.5.3 is released, of which release note refers to [release_note_0.5.3](https://celeborn.apache.org/community/release_notes/release_note_0.5.3/).

# What changes are included in this PR?

Bump Celeborn version from 0.5.2 to 0.5.3 including bump the following commit:

- https://github.com/apache/celeborn/pull/2894

# Are there any user-facing changes?

No.