### PR TITLE
[BLAZE-762] Return null when log function input is negative

### DIFF
--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeQuerySuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeQuerySuite.scala
@@ -80,4 +80,14 @@ class BlazeQuerySuite extends org.apache.spark.sql.QueryTest with BaseBlazeSQLSu
           Seq(Row(1, ArrayBuffer("test", "blaze"), Map("one" -> "1", "zero" -> "0"))))
       })
   }
+
+  test("log function with negative input") {
+    withTable("t1") {
+      sql("create table t1 using parquet as select -1 as c1")
+      spark.table("t1").printSchema()
+      val df = sql("select ln(c1) from t1")
+      df.show()
+      checkAnswer(df, Seq(Row(null)))
+    }
+  }
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeConverters.scala
@@ -805,9 +805,12 @@ object NativeConverters extends Logging {
       case e: Acos => buildScalarFunction(pb.ScalarFunction.Acos, e.children, e.dataType)
       case e: Atan => buildScalarFunction(pb.ScalarFunction.Atan, e.children, e.dataType)
       case e: Exp => buildScalarFunction(pb.ScalarFunction.Exp, e.children, e.dataType)
-      case e: Log => buildScalarFunction(pb.ScalarFunction.Ln, e.children, e.dataType)
-      case e: Log2 => buildScalarFunction(pb.ScalarFunction.Log2, e.children, e.dataType)
-      case e: Log10 => buildScalarFunction(pb.ScalarFunction.Log10, e.children, e.dataType)
+      case e: Log =>
+        buildScalarFunction(pb.ScalarFunction.Ln, e.children.map(nullIfNegative), e.dataType)
+      case e: Log2 =>
+        buildScalarFunction(pb.ScalarFunction.Log2, e.children.map(nullIfNegative), e.dataType)
+      case e: Log10 =>
+        buildScalarFunction(pb.ScalarFunction.Log10, e.children.map(nullIfNegative), e.dataType)
       case e: Floor if !e.dataType.isInstanceOf[DecimalType] =>
         buildExprNode {
           _.setTryCast(
@@ -1227,6 +1230,10 @@ object NativeConverters extends Logging {
       case expr: Cast if expr.dataType == BinaryType => expr.child
       case expr => expr
     }
+
+  def nullIfNegative(expr: Expression): Expression = {
+    If(LessThanOrEqual(expr, Literal.default(expr.dataType)), Literal(null, expr.dataType), expr)
+  }
 
   def serializeExpression[E <: Expression](
       expr: E with Serializable,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #762.

# Rationale for this change

Fix result mismatch of log functions

# What changes are included in this PR?

Return null when log function input is negative

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
