### PR TITLE
use better aggregate OwnedKey construction

### DIFF
--- a/native-engine/datafusion-ext-plans/src/agg/acc.rs
+++ b/native-engine/datafusion-ext-plans/src/agg/acc.rs
@@ -587,7 +587,7 @@ impl AccColumn for AccGenericColumn {
                     let len = read_len(&mut r)?;
                     if len > 0 {
                         let len = len - 1;
-                        let bytes = AccBytes::from({
+                        let bytes = AccBytes::from_vec({
                             let vec: Vec<u8> = read_bytes_slice(&mut r, len)?.into();
                             vec
                         });

--- a/native-engine/datafusion-ext-plans/src/agg/agg_hash_map.rs
+++ b/native-engine/datafusion-ext-plans/src/agg/agg_hash_map.rs
@@ -180,7 +180,7 @@ impl AggHashMapKey for &[u8] {
     }
 
     fn into_owned(self) -> OwnedKey {
-        OwnedKey::from(self)
+        OwnedKey::from_slice(self)
     }
 }
 


### PR DESCRIPTION
`SmallVec::from()` creates a vector with larger capacity than len, which leads to probable oom. we should use `SmallVec::from_slice()` instead.