### PR TITLE
[BLAZE-786] Mark big decimal value convertion as unsupported

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeConverters.scala
@@ -123,7 +123,10 @@ object NativeConverters extends Logging {
       case NullType | BooleanType | ByteType | ShortType | IntegerType | LongType | FloatType |
           DoubleType | StringType | DateType | TimestampType =>
         true
-      case _: DecimalType => true
+      case t: DecimalType  if DecimalType.is64BitDecimalType(t) => true
+      case _: DecimalType =>
+        // blaze only supports 64-bit decimal
+        false
       case at: ArrayType => scalarTypeSupported(at.elementType)
       case m: MapType =>
         scalarTypeSupported(m.keyType) && scalarTypeSupported(m.valueType)

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeConverters.scala
@@ -123,7 +123,7 @@ object NativeConverters extends Logging {
       case NullType | BooleanType | ByteType | ShortType | IntegerType | LongType | FloatType |
           DoubleType | StringType | DateType | TimestampType =>
         true
-      case t: DecimalType  if DecimalType.is64BitDecimalType(t) => true
+      case t: DecimalType if DecimalType.is64BitDecimalType(t) => true
       case _: DecimalType =>
         // blaze only supports 64-bit decimal
         false


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #786.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Avoid overflow when converting big decimal to native in native range shuffle

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Mark big decimal value convertion as unsupported

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
