### PR TITLE
[BLAZE-790] Support LZ4_RAW compression codec for parquet

### DIFF
--- a/native-engine/datafusion-ext-plans/src/parquet_sink_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/parquet_sink_exec.rs
@@ -377,6 +377,7 @@ fn parse_writer_props(prop_kvs: &[(String, String)]) -> WriterProperties {
                     "LZO" => Compression::LZO,
                     "BROTLI" => Compression::BROTLI(BrotliLevel::default()),
                     "LZ4" => Compression::LZ4,
+                    "LZ4RAW" | "LZ4_RAW" => Compression::LZ4_RAW,
                     "ZSTD" => {
                         let level_default = ZstdLevel::default().compression_level();
                         let level = prop_kvs


### PR DESCRIPTION
# Which issue does this PR close?

Closes #790.

 # Rationale for this change

Spark has already supported `LZ4_RAW` compression codec for parquet in Spark 3.5 with https://github.com/apache/spark/pull/41507. Meanwhile, arrow-rs has also supported `LZ4_RAW` parquet compression codec in https://github.com/apache/arrow-rs/blob/main/parquet/src/compression.rs#L187C20-L187C27. Therefore, it's recommended to support LZ4_RAW compression codec for parquet.

# What changes are included in this PR?

Support `LZ4_RAW` compression codec for parquet in `parquet_sink_exec.rs`.

# Are there any user-facing changes?

No.