### PR TITLE
Add support of pprof dump for rust execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0966165eaf052580bd70eb1b32cb3d6245774c0104d1b2793e9650bf83b52a"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,7 +158,7 @@ name = "arrow-buffer"
 version = "53.0.0"
 source = "git+https://github.com/blaze-init/arrow-rs.git?rev=f34f7eb3c2#f34f7eb3c2ee666f82ce5e042521ad2a0ddb62b9"
 dependencies = [
- "bytes",
+ "bytes 1.9.0",
  "half",
  "num",
 ]
@@ -165,7 +174,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "comfy-table",
  "half",
@@ -362,6 +371,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -424,13 +439,19 @@ dependencies = [
  "datafusion-ext-commons",
  "datafusion-ext-plans",
  "futures",
- "jemallocator",
+ "jemalloc_pprof",
  "jni",
  "log",
  "once_cell",
  "panic-message",
  "paste",
+ "poem",
+ "pprof",
  "prost 0.13.4",
+ "serde",
+ "tikv-jemalloc-ctl",
+ "tikv-jemalloc-sys",
+ "tikv-jemallocator",
  "tokio",
 ]
 
@@ -450,7 +471,7 @@ name = "blaze-serde"
 version = "0.1.0"
 dependencies = [
  "arrow",
- "base64",
+ "base64 0.22.1",
  "datafusion",
  "datafusion-ext-commons",
  "datafusion-ext-exprs",
@@ -510,6 +531,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
@@ -607,7 +634,7 @@ version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
- "bytes",
+ "bytes 1.9.0",
  "memchr",
 ]
 
@@ -659,6 +686,15 @@ name = "count-write"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced507ab50aa0123e2c54db8b5f44fdfee04b1c93744d69e924307945fe57a85"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -747,7 +783,7 @@ dependencies = [
  "arrow-schema",
  "async-compression",
  "async-trait",
- "bytes",
+ "bytes 1.9.0",
  "bzip2",
  "chrono",
  "dashmap",
@@ -898,7 +934,7 @@ dependencies = [
  "bitvec",
  "blaze-jni-bridge",
  "byteorder",
- "bytes",
+ "bytes 1.9.0",
  "datafusion",
  "futures",
  "itertools 0.14.0",
@@ -957,11 +993,11 @@ dependencies = [
  "arrow",
  "arrow-schema",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bitvec",
  "blaze-jni-bridge",
  "byteorder",
- "bytes",
+ "bytes 1.9.0",
  "bytesize",
  "count-write",
  "datafusion",
@@ -1000,7 +1036,7 @@ source = "git+https://github.com/blaze-init/arrow-datafusion.git?rev=e9e2128a7#e
 dependencies = [
  "arrow",
  "arrow-buffer",
- "base64",
+ "base64 0.22.1",
  "blake2",
  "blake3",
  "chrono",
@@ -1116,7 +1152,7 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "arrow-string",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "datafusion-common",
  "datafusion-execution",
@@ -1212,6 +1248,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,6 +1296,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "equator"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35da53b5a021d2484a7cc49b2ac7f2d840f8236a286f84202369bd338d761ea"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,7 +1328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1284,10 +1349,22 @@ version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9154486833a83cb5d99de8c4d831314b8ae810dd4ef18d89ceb7a9c7c728dd74"
 dependencies = [
- "bytes",
+ "bytes 1.9.0",
  "rkyv",
  "serde",
  "simdutf8",
+]
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1315,6 +1392,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1427,6 +1510,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures_codec"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
+dependencies = [
+ "bytes 0.5.6",
+ "futures",
+ "memchr",
+ "pin-project",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,6 +1555,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes 1.9.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1601,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.7",
+ "bytes 1.9.0",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,16 +1637,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes 1.9.0",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes 1.9.0",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes 1.9.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1683,6 +1885,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
+dependencies = [
+ "ahash",
+ "indexmap",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +1919,17 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
+dependencies = [
+ "hermit-abi 0.4.0",
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "itertools"
@@ -1734,23 +1965,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
-name = "jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
+name = "jemalloc_pprof"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+checksum = "1a883828bd6a4b957cd9f618886ff19e5f3ebd34e06ba0e855849e049fef32fb"
 dependencies = [
- "cc",
+ "anyhow",
  "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
-dependencies = [
- "jemalloc-sys",
- "libc",
+ "mappings",
+ "once_cell",
+ "pprof_util",
+ "tempfile",
+ "tikv-jemalloc-ctl",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1933,6 +2161,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mappings"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9229c438fbf1c333926e2053c4c091feabbd40a1b590ec62710fea2384af9e"
+dependencies = [
+ "anyhow",
+ "libc",
+ "once_cell",
+ "pprof_util",
+ "tracing",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,12 +2190,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1981,6 +2248,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.91",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2014,6 +2303,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
 ]
 
 [[package]]
@@ -2063,7 +2362,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -2083,7 +2382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eb4c22c6154a1e759d7099f9ffad7cc5ef8245f9efbab4a41b92623079c82f3"
 dependencies = [
  "async-trait",
- "bytes",
+ "bytes 1.9.0",
  "chrono",
  "futures",
  "humantime",
@@ -2111,7 +2410,7 @@ dependencies = [
  "arrow",
  "async-trait",
  "bytemuck",
- "bytes",
+ "bytes 1.9.0",
  "chrono",
  "chrono-tz",
  "fallible-streaming-iterator",
@@ -2179,9 +2478,9 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64",
+ "base64 0.22.1",
  "brotli",
- "bytes",
+ "bytes 1.9.0",
  "chrono",
  "flate2",
  "futures",
@@ -2271,6 +2570,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2287,6 +2606,90 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "poem"
+version = "1.3.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504774c97b0744c1ee108a37e5a65a9745a4725c4c06277521dabc28eb53a904"
+dependencies = [
+ "async-trait",
+ "bytes 1.9.0",
+ "futures-util",
+ "headers",
+ "http",
+ "hyper",
+ "mime",
+ "nix 0.27.1",
+ "parking_lot",
+ "percent-encoding",
+ "pin-project-lite",
+ "poem-derive",
+ "regex",
+ "rfc7239",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec 1.13.2",
+ "sse-codec",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "wildmatch",
+]
+
+[[package]]
+name = "poem-derive"
+version = "1.3.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ddcf4680d8d867e1e375116203846acb088483fa2070244f90589f458bbb31"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
+]
+
+[[package]]
+name = "pprof"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebbe2f8898beba44815fdc9e5a4ae9c929e21c5dc29b0c774a15555f7f58d6d0"
+dependencies = [
+ "aligned-vec",
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "once_cell",
+ "parking_lot",
+ "protobuf",
+ "protobuf-codegen-pure",
+ "smallvec 1.13.2",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "pprof_util"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c568b3f8c1c37886ae07459b1946249e725c315306b03be5632f84c239f781"
+dependencies = [
+ "anyhow",
+ "flate2",
+ "num",
+ "paste",
+ "prost 0.13.4",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -2308,6 +2711,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+dependencies = [
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2322,7 +2735,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
- "bytes",
+ "bytes 1.9.0",
  "prost-derive 0.12.6",
 ]
 
@@ -2332,7 +2745,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
 dependencies = [
- "bytes",
+ "bytes 1.9.0",
  "prost-derive 0.13.4",
 ]
 
@@ -2392,6 +2805,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
+dependencies = [
+ "protobuf",
+]
+
+[[package]]
+name = "protobuf-codegen-pure"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a29399fc94bcd3eeaa951c715f7bea69409b2445356b00519740bcd6ddd865"
+dependencies = [
+ "protobuf",
+ "protobuf-codegen",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2409,6 +2847,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.91",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2536,12 +2983,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215"
 
 [[package]]
+name = "rfc7239"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a82f1d1e38e9a85bb58ffcfadf22ed6f2c94e8cd8581ec2b0f80a2a6858350f"
+dependencies = [
+ "uncased",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11a153aec4a6ab60795f8ebe2923c597b16b05bb1504377451e705ef1a45323"
 dependencies = [
- "bytes",
+ "bytes 1.9.0",
  "hashbrown 0.15.2",
  "indexmap",
  "munge",
@@ -2589,7 +3069,38 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2618,6 +3129,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "semver"
@@ -2659,6 +3180,29 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2739,6 +3283,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
+name = "socket2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "sonic-number"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2754,7 +3308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0275f9f2f07d47556fe60c2759da8bc4be6083b047b491b2d476aa0bfa558eb1"
 dependencies = [
  "bumpalo",
- "bytes",
+ "bytes 1.9.0",
  "cfg-if",
  "faststr",
  "itoa",
@@ -2775,6 +3329,12 @@ checksum = "940a24e82c9a97483ef66cef06b92160a8fa5cd74042c57c10b24d99d169d2fc"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sqlparser"
@@ -2798,6 +3358,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-codec"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a59f811350c44b4a037aabeb72dc6a9591fc22aa95a036db9a96297c58085a"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-io",
+ "futures_codec",
+ "memchr",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2808,6 +3380,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 
 [[package]]
 name = "strum"
@@ -2836,6 +3414,29 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symbolic-common"
+version = "12.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a4dfe4bbeef59c1f32fc7524ae7c95b9e1de5e79a43ce1604e181081d71b0c"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cf6a95abff97de4d7ff3473f33cacd38f1ddccad5c1feab435d6760300e3b6"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
+]
 
 [[package]]
 name = "syn"
@@ -2887,7 +3488,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2953,6 +3554,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21f216790c8df74ce3ab25b534e0718da5a1916719771d3fec23315c99e468b"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2993,9 +3625,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
- "bytes",
+ "bytes 1.9.0",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3010,16 +3646,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
- "bytes",
+ "bytes 1.9.0",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -3035,6 +3710,12 @@ dependencies = [
  "quote",
  "syn 2.0.91",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -3068,6 +3749,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3082,6 +3769,15 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unchecked-index"
@@ -3106,6 +3802,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -3153,6 +3855,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -3226,19 +3937,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "wildmatch"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ce1ab1f8c62655ebe1350f589c61e505cf94d385bc6a12899442d9081e71fd"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]
@@ -3315,6 +4063,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "write16"

--- a/native-engine/blaze/Cargo.toml
+++ b/native-engine/blaze/Cargo.toml
@@ -8,7 +8,9 @@ resolver = "1"
 crate-type = ["cdylib"]
 
 [features]
-default = ["tokio/rt-multi-thread"]
+default = ["tokio/rt-multi-thread", "jemalloc"]
+
+jemalloc = ["dep:tikv-jemalloc-ctl", "dep:tikv-jemalloc-sys", "dep:tikv-jemallocator", "dep:jemalloc_pprof", "dep:pprof"]
 
 [dependencies]
 arrow = { workspace = true }
@@ -26,6 +28,29 @@ panic-message = "0.3.0"
 paste = "1.0.15"
 prost = "0.13.4"
 tokio = "1.43.0"
+poem = { version = "1.3.56", features = ["rustls", "test"] }
+serde = { version = "1", features = ["derive"] }
 
-[target.'cfg(not(windows))'.dependencies]
-jemallocator = { version = "0.5.0", features = ["disable_initial_exec_tls"] }
+[dependencies.tikv-jemalloc-ctl]
+version = "0.6.0"
+optional = true
+features = ["use_std"]
+
+[dependencies.tikv-jemalloc-sys]
+version = "0.6.0"
+optional = true
+features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms"]
+
+[dependencies.tikv-jemallocator]
+version = "0.6.0"
+optional = true
+features = ["profiling", "unprefixed_malloc_on_supported_platforms"]
+
+[dependencies.jemalloc_pprof]
+version = "0.6.0"
+optional = true
+
+[dependencies.pprof]
+version = "0.14.0"
+features = ["flamegraph", "protobuf-codec", "protobuf"]
+optional = true

--- a/native-engine/blaze/Cargo.toml
+++ b/native-engine/blaze/Cargo.toml
@@ -48,7 +48,7 @@ features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms", "d
 [dependencies.tikv-jemallocator]
 version = "0.6.0"
 optional = true
-features = ["profiling", "unprefixed_malloc_on_supported_platforms"]
+features = ["profiling", "unprefixed_malloc_on_supported_platforms", "disable_initial_exec_tls"]
 
 [dependencies.jemalloc_pprof]
 version = "0.6.0"

--- a/native-engine/blaze/Cargo.toml
+++ b/native-engine/blaze/Cargo.toml
@@ -10,9 +10,9 @@ crate-type = ["cdylib"]
 [features]
 default = ["tokio/rt-multi-thread", "jemalloc"]
 
-jemalloc = ["dep:tikv-jemalloc-ctl", "dep:tikv-jemalloc-sys", "dep:tikv-jemallocator"]
+jemalloc = ["dep:tikv-jemallocator"]
 
-jemalloc-pprof = ["dep:jemalloc_pprof", "dep:pprof", "http-service"]
+jemalloc-pprof = ["dep:tikv-jemalloc-ctl", "dep:tikv-jemalloc-sys", "dep:jemalloc_pprof", "dep:pprof", "http-service"]
 
 http-service = []
 

--- a/native-engine/blaze/Cargo.toml
+++ b/native-engine/blaze/Cargo.toml
@@ -48,7 +48,7 @@ features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms", "d
 [dependencies.tikv-jemallocator]
 version = "0.6.0"
 optional = true
-features = ["profiling", "unprefixed_malloc_on_supported_platforms", "disable_initial_exec_tls"]
+features = ["disable_initial_exec_tls"]
 
 [dependencies.jemalloc_pprof]
 version = "0.6.0"

--- a/native-engine/blaze/Cargo.toml
+++ b/native-engine/blaze/Cargo.toml
@@ -39,7 +39,7 @@ features = ["use_std"]
 [dependencies.tikv-jemalloc-sys]
 version = "0.6.0"
 optional = true
-features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms"]
+features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms", "disable_initial_exec_tls"]
 
 [dependencies.tikv-jemallocator]
 version = "0.6.0"

--- a/native-engine/blaze/Cargo.toml
+++ b/native-engine/blaze/Cargo.toml
@@ -10,7 +10,11 @@ crate-type = ["cdylib"]
 [features]
 default = ["tokio/rt-multi-thread", "jemalloc"]
 
-jemalloc = ["dep:tikv-jemalloc-ctl", "dep:tikv-jemalloc-sys", "dep:tikv-jemallocator", "dep:jemalloc_pprof", "dep:pprof"]
+jemalloc = ["dep:tikv-jemalloc-ctl", "dep:tikv-jemalloc-sys", "dep:tikv-jemallocator"]
+
+jemalloc-pprof = ["dep:jemalloc_pprof", "dep:pprof", "http-service"]
+
+http-service = []
 
 [dependencies]
 arrow = { workspace = true }

--- a/native-engine/blaze/src/alloc.rs
+++ b/native-engine/blaze/src/alloc.rs
@@ -14,9 +14,6 @@ use std::{
 #[cfg_attr(not(windows), global_allocator)]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-#[cfg(not(feature = "jemalloc"))]
-static GLOBAL: std::alloc::System = std::alloc::System;
-
 // only used for debugging
 //
 // #[global_allocator]

--- a/native-engine/blaze/src/alloc.rs
+++ b/native-engine/blaze/src/alloc.rs
@@ -9,9 +9,13 @@ use std::{
     },
 };
 
+#[cfg(feature = "jemalloc")]
 #[cfg(not(windows))]
 #[cfg_attr(not(windows), global_allocator)]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+#[cfg(not(feature = "jemalloc"))]
+static GLOBAL: std::alloc::System = std::alloc::System;
 
 // only used for debugging
 //

--- a/native-engine/blaze/src/exec.rs
+++ b/native-engine/blaze/src/exec.rs
@@ -54,9 +54,8 @@ pub extern "system" fn Java_org_apache_spark_sql_blaze_JniBridge_callNative(
         static SESSION: OnceCell<SessionContext> = OnceCell::new();
         static INIT: OnceCell<()> = OnceCell::new();
 
-        eprintln!("gotten http service.");
         let _ = HTTP_SERVICE.get_or_try_init(|| {
-            eprintln!("init http service.");
+            eprintln!("initializing http service...");
             Ok::<HttpService, DataFusionError>(HttpService::init())
         });
 

--- a/native-engine/blaze/src/http/mod.rs
+++ b/native-engine/blaze/src/http/mod.rs
@@ -1,0 +1,81 @@
+mod pprof;
+
+use std::sync::Mutex;
+
+use log::{info, warn};
+use once_cell::sync::{Lazy, OnceCell};
+use poem::{listener::TcpListener, Route, RouteMethod, Server};
+
+use crate::http::pprof::PProfHandler;
+
+pub static HTTP_SERVICE: OnceCell<HttpService> = OnceCell::new();
+
+pub trait Handler {
+    fn get_route_method(&self) -> RouteMethod;
+    fn get_route_path(&self) -> String;
+}
+
+pub trait HTTPServer: Send + Sync {
+    fn start(&self);
+    fn register_handler(&self, handler: impl Handler + 'static);
+}
+
+pub struct DefaultHTTPServer {
+    runtime: tokio::runtime::Runtime,
+    handlers: Mutex<Vec<Box<dyn Handler>>>,
+}
+
+unsafe impl Send for DefaultHTTPServer {}
+unsafe impl Sync for DefaultHTTPServer {}
+
+impl DefaultHTTPServer {
+    pub fn new() -> Self {
+        Self {
+            runtime: tokio::runtime::Builder::new_multi_thread().build().unwrap(),
+            handlers: Mutex::new(vec![]),
+        }
+    }
+}
+
+fn find_available_port() -> Option<u16> {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .ok()
+        .and_then(|listener| listener.local_addr().ok().map(|addr| addr.port()))
+}
+
+impl HTTPServer for DefaultHTTPServer {
+    fn start(&self) {
+        if let Some(port) = find_available_port() {
+            let mut app = Route::new();
+            let handlers = self.handlers.lock().unwrap();
+            for handler in handlers.iter() {
+                app = app.at(handler.get_route_path(), handler.get_route_method());
+            }
+            self.runtime.spawn(async move {
+                let _ = Server::new(TcpListener::bind(format!("0.0.0.0:{}", port)))
+                    .name("blaze-native-http-service")
+                    .run(app)
+                    .await;
+            });
+            eprintln!("Blaze http service started. port: {}", port);
+        } else {
+            eprintln!("Failed to find an available port and http service is disabled!")
+        }
+    }
+
+    fn register_handler(&self, handler: impl Handler + 'static) {
+        let mut handlers = self.handlers.lock().unwrap();
+        handlers.push(Box::new(handler));
+    }
+}
+
+pub struct HttpService;
+
+impl HttpService {
+    pub fn init() -> Self {
+        let server = DefaultHTTPServer::new();
+        server.register_handler(PProfHandler::default());
+        server.start();
+        Self
+    }
+}

--- a/native-engine/blaze/src/http/mod.rs
+++ b/native-engine/blaze/src/http/mod.rs
@@ -30,7 +30,11 @@ unsafe impl Sync for DefaultHTTPServer {}
 impl DefaultHTTPServer {
     pub fn new() -> Self {
         Self {
-            runtime: tokio::runtime::Builder::new_multi_thread().build().unwrap(),
+            runtime: tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_io()
+                .build()
+                .unwrap(),
             handlers: Mutex::new(vec![]),
         }
     }

--- a/native-engine/blaze/src/http/mod.rs
+++ b/native-engine/blaze/src/http/mod.rs
@@ -1,11 +1,10 @@
+#[cfg(feature = "jemalloc-pprof")]
 mod pprof;
 
 use std::sync::Mutex;
 
 use once_cell::sync::OnceCell;
 use poem::{listener::TcpListener, Route, RouteMethod, Server};
-
-use crate::http::pprof::PProfHandler;
 
 pub static HTTP_SERVICE: OnceCell<HttpService> = OnceCell::new();
 
@@ -77,7 +76,11 @@ pub struct HttpService;
 impl HttpService {
     pub fn init() -> Self {
         let server = DefaultHTTPServer::new();
-        server.register_handler(PProfHandler::default());
+        #[cfg(feature = "jemalloc-pprof")]
+        {
+            use crate::http::pprof::PProfHandler;
+            server.register_handler(PProfHandler::default());
+        }
         server.start();
         Self
     }

--- a/native-engine/blaze/src/http/mod.rs
+++ b/native-engine/blaze/src/http/mod.rs
@@ -2,8 +2,7 @@ mod pprof;
 
 use std::sync::Mutex;
 
-use log::{info, warn};
-use once_cell::sync::{Lazy, OnceCell};
+use once_cell::sync::OnceCell;
 use poem::{listener::TcpListener, Route, RouteMethod, Server};
 
 use crate::http::pprof::PProfHandler;

--- a/native-engine/blaze/src/http/pprof.rs
+++ b/native-engine/blaze/src/http/pprof.rs
@@ -1,0 +1,93 @@
+use std::num::NonZeroI32;
+
+use log::error;
+use poem::{handler, http::StatusCode, Request, RouteMethod};
+use pprof::{protos::Message, ProfilerGuard};
+use serde::{Deserialize, Serialize};
+use tokio::time::{sleep as delay_for, Duration};
+
+use crate::http::Handler;
+
+#[derive(Deserialize, Serialize)]
+#[serde(default)]
+pub struct PProfRequest {
+    pub(crate) seconds: u64,
+    pub(crate) frequency: NonZeroI32,
+}
+
+impl Default for PProfRequest {
+    fn default() -> Self {
+        PProfRequest {
+            seconds: 5,
+            frequency: NonZeroI32::new(100).unwrap(),
+        }
+    }
+}
+
+#[handler]
+async fn pprof_handler(req: &Request) -> poem::Result<Vec<u8>> {
+    let req = req.params::<PProfRequest>()?;
+    let mut body: Vec<u8> = Vec::new();
+
+    let guard = ProfilerGuard::new(req.frequency.into()).map_err(|e| {
+        let msg = format!("could not start profiling: {:?}", e);
+        error!("{}", msg);
+        return poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR);
+    })?;
+    delay_for(Duration::from_secs(req.seconds)).await;
+    let report = guard.report().build().map_err(|e| {
+        let msg = format!("could not build profiling report: {:?}", e);
+        error!("{}", msg);
+        return poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR);
+    })?;
+    let profile = report.pprof().map_err(|e| {
+        let msg = format!("could not get pprof profile: {:?}", e);
+        error!("{}", msg);
+        return poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR);
+    })?;
+    profile.write_to_vec(&mut body).map_err(|e| {
+        let msg = format!("could not write pprof profile: {:?}", e);
+        error!("{}", msg);
+        return poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR);
+    })?;
+    Ok(body)
+}
+
+pub struct PProfHandler;
+
+impl Default for PProfHandler {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl Handler for PProfHandler {
+    fn get_route_method(&self) -> RouteMethod {
+        RouteMethod::new().get(pprof_handler)
+    }
+
+    fn get_route_path(&self) -> String {
+        "/debug/pprof/profile".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use poem::{test::TestClient, Route};
+
+    use crate::http::{pprof::PProfHandler, Handler};
+
+    #[tokio::test]
+    async fn test_router() {
+        let handler = PProfHandler::default();
+        let app = Route::new().at(handler.get_route_path(), handler.get_route_method());
+        let cli = TestClient::new(app);
+        let resp = cli
+            .get("/debug/pprof/profile")
+            .query("seconds", &4)
+            .query("frequency", &100)
+            .send()
+            .await;
+        resp.assert_status_is_ok();
+    }
+}

--- a/native-engine/blaze/src/lib.rs
+++ b/native-engine/blaze/src/lib.rs
@@ -19,6 +19,7 @@ use jni::objects::{JObject, JThrowable};
 
 mod alloc;
 mod exec;
+mod http;
 mod logging;
 mod metrics;
 mod rt;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change

Currently, the native side execution flamegraph could not be collected by pprof, this PR support this.

# What changes are included in this PR?

1. Introduce the general http service for exposing the api to get the pprof data
2. Change the jemalloc to the tikv-jemalloc for pprof. In the future, it also could dump the heap sample.


# Are there any user-facing changes?

No. But the pprof usage could be introduced for users in the next PRs
