### PR TITLE
Automatic cancel previous CI tests when newly commit comes for per PR

### DIFF
--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-spark-30:
     name: Test spark-3.0


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change

The ci of TPCDS costs too much time for github actions, and so if newly commits come, the previous CI won't be cancelled, this will block users to see the latest CI result.

# What changes are included in this PR?

Automatic previous CI tests when newly commit comes for per PR

# Are there any user-facing changes?

No

