### PR TITLE
Add support of Apache Uniffle for remote shuffle service

### DIFF
--- a/spark-extension-shims-spark3/pom.xml
+++ b/spark-extension-shims-spark3/pom.xml
@@ -56,6 +56,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.uniffle</groupId>
+      <artifactId>rss-client-spark3-shaded</artifactId>
+      <version>0.9.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-c-data</artifactId>
     </dependency>

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/shuffle/uniffle/RssShuffleHandleWrapper.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/shuffle/uniffle/RssShuffleHandleWrapper.scala
@@ -13,14 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.execution.blaze.shuffle
+package org.apache.spark.shuffle.uniffle
 
-import java.nio.ByteBuffer
+import org.apache.spark.shuffle.{BaseShuffleHandle, RssShuffleHandle}
 
-trait RssPartitionWriterBase {
-  def write(partitionId: Int, buffer: ByteBuffer): Unit
-  def flush(): Unit
-  def close(): Unit
-  def getPartitionLengthMap: Array[Long]
-  def stop(isSuccess: Boolean): Unit
-}
+class RssShuffleHandleWrapper[K, V, C](val rssShuffleHandleInfo: RssShuffleHandle[K, V, C])
+    extends BaseShuffleHandle[K, V, C](
+      rssShuffleHandleInfo.getShuffleId,
+      rssShuffleHandleInfo.getDependency) {}

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/blaze/ShimsImpl.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/blaze/ShimsImpl.scala
@@ -112,6 +112,7 @@ import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.storage.FileSegment
 import org.blaze.{protobuf => pb}
 import com.thoughtworks.enableIf
+import org.apache.spark.sql.execution.blaze.shuffle.uniffle.BlazeUniffleShuffleManager
 
 class ShimsImpl extends Shims with Logging {
 
@@ -429,7 +430,9 @@ class ShimsImpl extends Shims with Logging {
       input: pb.PhysicalPlanNode,
       nativeOutputPartitioning: pb.PhysicalRepartition.Builder): pb.PhysicalPlanNode = {
 
-    if (SparkEnv.get.shuffleManager.isInstanceOf[BlazeCelebornShuffleManager]) {
+    if (SparkEnv.get.shuffleManager
+        .isInstanceOf[BlazeCelebornShuffleManager] || SparkEnv.get.shuffleManager
+        .isInstanceOf[BlazeUniffleShuffleManager]) {
       return pb.PhysicalPlanNode
         .newBuilder()
         .setRssShuffleWriter(

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/CelebornPartitionWriter.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/CelebornPartitionWriter.scala
@@ -66,7 +66,7 @@ class CelebornPartitionWriter(
   override def getPartitionLengthMap: Array[Long] =
     mapStatusLengths
 
-  override def stop(): Unit = {
+  override def stop(isSuccess: Boolean): Unit = {
     shuffleClient.cleanup(shuffleId, mapId, encodedAttemptId)
   }
 }

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleManager.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleManager.scala
@@ -98,7 +98,7 @@ class BlazeUniffleShuffleManager(conf: SparkConf, isDriver: Boolean)
       context: TaskContext,
       metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
     val rssHandle = handle.asInstanceOf[RssShuffleHandleWrapper[K, _, C]].rssShuffleHandleInfo
-    uniffleShuffleManager.getReaderForRange(
+    uniffleShuffleManager.getReader(
       rssHandle,
       startMapIndex,
       endMapIndex,

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleManager.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleManager.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2022 The Blaze Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.blaze.shuffle.uniffle
+
+import org.apache.spark.shuffle.reader.RssShuffleReader
+import org.apache.spark.shuffle.uniffle.RssShuffleHandleWrapper
+import org.apache.spark.shuffle.writer.RssShuffleWriter
+import org.apache.spark.shuffle.{RssShuffleHandle, RssShuffleManager, ShuffleBlockResolver, ShuffleHandle, ShuffleReadMetricsReporter, ShuffleReader, ShuffleWriteMetricsReporter, ShuffleWriter}
+import org.apache.spark.{ShuffleDependency, SparkConf, TaskContext}
+import org.apache.spark.sql.execution.blaze.shuffle.{BlazeRssShuffleManagerBase, BlazeRssShuffleReaderBase, BlazeRssShuffleWriterBase}
+
+class BlazeUniffleShuffleManager(conf: SparkConf, isDriver: Boolean)
+    extends BlazeRssShuffleManagerBase(conf) {
+  private val uniffleShuffleManager: RssShuffleManager = new RssShuffleManager(conf, isDriver);
+  override def registerShuffle[K, V, C](
+      shuffleId: Int,
+      dependency: ShuffleDependency[K, V, C]): ShuffleHandle = {
+    val handle = uniffleShuffleManager.registerShuffle(shuffleId, dependency)
+    new RssShuffleHandleWrapper(handle.asInstanceOf[RssShuffleHandle[K, V, C]])
+  }
+
+  override def unregisterShuffle(shuffleId: Int): Boolean = {
+    uniffleShuffleManager.unregisterShuffle(shuffleId)
+  }
+
+  override def getBlazeRssShuffleReader[K, C](
+      handle: ShuffleHandle,
+      startPartition: Int,
+      endPartition: Int,
+      context: TaskContext,
+      metrics: ShuffleReadMetricsReporter): BlazeRssShuffleReaderBase[K, C] = {
+    getBlazeRssShuffleReader(
+      handle,
+      0,
+      Int.MaxValue,
+      startPartition,
+      endPartition,
+      context,
+      metrics)
+  }
+
+  override def getBlazeRssShuffleReader[K, C](
+      handle: ShuffleHandle,
+      startMapIndex: Int,
+      endMapIndex: Int,
+      startPartition: Int,
+      endPartition: Int,
+      context: TaskContext,
+      metrics: ShuffleReadMetricsReporter): BlazeRssShuffleReaderBase[K, C] = {
+    val rssHandleWrapper = handle.asInstanceOf[RssShuffleHandleWrapper[K, _, C]]
+    val reader =
+      uniffleShuffleManager.getReader(
+        rssHandleWrapper.rssShuffleHandleInfo,
+        startPartition,
+        endPartition,
+        context,
+        metrics)
+    new BlazeUniffleShuffleReader(
+      reader.asInstanceOf[RssShuffleReader[K, C]],
+      rssHandleWrapper,
+      startMapIndex,
+      endMapIndex,
+      startPartition,
+      endPartition,
+      context,
+      metrics)
+  }
+
+  override def getRssShuffleReader[K, C](
+      handle: ShuffleHandle,
+      startPartition: Int,
+      endPartition: Int,
+      context: TaskContext,
+      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
+    val rssHandle = handle.asInstanceOf[RssShuffleHandleWrapper[K, _, C]].rssShuffleHandleInfo
+    uniffleShuffleManager.getReader(rssHandle, startPartition, endPartition, context, metrics)
+  }
+
+  override def getRssShuffleReader[K, C](
+      handle: ShuffleHandle,
+      startMapIndex: Int,
+      endMapIndex: Int,
+      startPartition: Int,
+      endPartition: Int,
+      context: TaskContext,
+      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
+    val rssHandle = handle.asInstanceOf[RssShuffleHandleWrapper[K, _, C]].rssShuffleHandleInfo
+    uniffleShuffleManager.getReaderForRange(
+      rssHandle,
+      startMapIndex,
+      endMapIndex,
+      startPartition,
+      endPartition,
+      context,
+      metrics)
+  }
+
+  override def getBlazeRssShuffleWriter[K, V](
+      handle: ShuffleHandle,
+      mapId: Long,
+      context: TaskContext,
+      metrics: ShuffleWriteMetricsReporter): BlazeRssShuffleWriterBase[K, V] = {
+    val rssHandle = handle.asInstanceOf[RssShuffleHandleWrapper[K, _, V]].rssShuffleHandleInfo
+    val writer: ShuffleWriter[K, V] =
+      uniffleShuffleManager.getWriter(rssHandle, mapId, context, metrics)
+    new BlazeUniffleShuffleWriter(writer.asInstanceOf[RssShuffleWriter[K, V, _]], metrics)
+  }
+
+  override def getRssShuffleWriter[K, V](
+      handle: ShuffleHandle,
+      mapId: Long,
+      context: TaskContext,
+      metrics: ShuffleWriteMetricsReporter): ShuffleWriter[K, V] = {
+    val rssHandle = handle.asInstanceOf[RssShuffleHandleWrapper[K, _, V]].rssShuffleHandleInfo
+    uniffleShuffleManager.getWriter(rssHandle, mapId, context, metrics)
+  }
+
+  override def shuffleBlockResolver: ShuffleBlockResolver = {
+    uniffleShuffleManager.shuffleBlockResolver()
+  }
+
+  override def stop(): Unit = {
+    uniffleShuffleManager.stop()
+  }
+}

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleReader.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleReader.scala
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2022 The Blaze Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.blaze.shuffle.uniffle
+
+import org.apache.commons.lang3.reflect.FieldUtils
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.executor.ShuffleReadMetrics
+import org.apache.spark.internal.Logging
+import org.apache.spark.shuffle.ShuffleReadMetricsReporter
+import org.apache.spark.shuffle.reader.{RssShuffleDataIterator, RssShuffleReader}
+import org.apache.spark.shuffle.uniffle.RssShuffleHandleWrapper
+import org.apache.spark.sql.execution.blaze.shuffle.BlazeRssShuffleReaderBase
+import org.apache.spark.storage.BlockId
+import org.apache.spark.util.TaskCompletionListener
+import org.apache.spark.{ShuffleDependency, TaskContext}
+import org.apache.uniffle.client.api.ShuffleReadClient
+import org.apache.uniffle.client.factory.ShuffleClientFactory
+import org.apache.uniffle.client.util.RssClientConfig
+import org.apache.uniffle.common.config.RssConf
+import org.apache.uniffle.common.exception.RssException
+import org.apache.uniffle.common.{ShuffleDataDistributionType, ShuffleServerInfo}
+import org.apache.uniffle.shaded.org.roaringbitmap.longlong.Roaring64NavigableMap
+
+import java.io.InputStream
+import java.nio.ByteBuffer
+import java.util
+import scala.collection.AbstractIterator
+
+class BlazeUniffleShuffleReader[K, C](
+    reader: RssShuffleReader[K, C],
+    handle: RssShuffleHandleWrapper[K, _, C],
+    startMapIndex: Int,
+    endMapIndex: Int,
+    startPartition: Int,
+    endPartition: Int,
+    context: TaskContext,
+    metrics: ShuffleReadMetricsReporter)
+    extends BlazeRssShuffleReaderBase[K, C](handle, context)
+    with Logging {
+  private val numMaps: Int =
+    FieldUtils.readField(reader, "numMaps", true).asInstanceOf[Int]
+  private val partitionToExpectBlocks: util.Map[Integer, Roaring64NavigableMap] = FieldUtils
+    .readField(reader, "partitionToExpectBlocks", true)
+    .asInstanceOf[util.Map[Integer, Roaring64NavigableMap]]
+  private val partitionToShuffleServers: util.Map[Integer, util.List[ShuffleServerInfo]] =
+    FieldUtils
+      .readField(reader, "partitionToShuffleServers", true)
+      .asInstanceOf[util.Map[Integer, util.List[ShuffleServerInfo]]]
+  private val mapStartIndex: Int =
+    FieldUtils.readField(reader, "mapStartIndex", true).asInstanceOf[Int]
+  private val mapEndIndex: Int =
+    FieldUtils.readField(reader, "mapEndIndex", true).asInstanceOf[Int]
+  private val rssConf: RssConf =
+    FieldUtils.readField(reader, "rssConf", true).asInstanceOf[RssConf]
+  private val dependency = FieldUtils
+    .readField(reader, "shuffleDependency", true)
+    .asInstanceOf[ShuffleDependency[K, _, C]]
+  private val appId: String =
+    FieldUtils.readField(reader, "appId", true).asInstanceOf[String]
+  private val shuffleId: Int =
+    FieldUtils.readField(reader, "shuffleId", true).asInstanceOf[Int]
+  private val basePath: String =
+    FieldUtils.readField(reader, "basePath", true).asInstanceOf[String]
+  private val partitionNum: Int =
+    FieldUtils.readField(reader, "partitionNum", true).asInstanceOf[Int]
+  private val taskIdBitmap: Roaring64NavigableMap = FieldUtils
+    .readField(reader, "taskIdBitmap", true)
+    .asInstanceOf[Roaring64NavigableMap]
+  private val hadoopConf: Configuration =
+    FieldUtils.readField(reader, "hadoopConf", true).asInstanceOf[Configuration]
+  private val dataDistributionType: ShuffleDataDistributionType = FieldUtils
+    .readField(reader, "dataDistributionType", true)
+    .asInstanceOf[ShuffleDataDistributionType]
+  private val readMetrics: ShuffleReadMetrics =
+    FieldUtils.readField(reader, "readMetrics", true).asInstanceOf[ShuffleReadMetrics]
+
+  override protected def readBlocks(): Iterator[(BlockId, InputStream)] = {
+    val inputStream =
+      new UniffleInputStream(new MultiPartitionIterator[K, C](), shuffleId, startPartition, endPartition)
+    Iterator.single((null, inputStream))
+  }
+
+  private class MultiPartitionIterator[K, C] extends AbstractIterator[Product2[K, C]] {
+    private var iterators: util.Iterator[RssShuffleDataIterator[K, C]] = null
+    private var currentIterator: RssShuffleDataIterator[K, C] = null
+
+    if (numMaps > 0) {
+      val shuffleDataIterList: util.List[RssShuffleDataIterator[K, C]] =
+        new util.ArrayList[RssShuffleDataIterator[K, C]]()
+
+      val emptyPartitionIds = new util.ArrayList[Int]
+      for (partition <- startPartition until endPartition) {
+        if (partitionToExpectBlocks.get(partition).isEmpty) {
+          emptyPartitionIds.add(partition)
+        } else {
+          val shuffleServerInfoList: util.List[ShuffleServerInfo] =
+            partitionToShuffleServers.get(partition)
+          // This mechanism of expectedTaskIdsBitmap filter is to filter out the most of data.
+          // especially for AQE skew optimization
+          val expectedTaskIdsBitmapFilterEnable: Boolean =
+            !(mapStartIndex == 0 && mapEndIndex == Integer.MAX_VALUE) || shuffleServerInfoList.size > 1
+          val retryMax: Int = rssConf.getInteger(
+            RssClientConfig.RSS_CLIENT_RETRY_MAX,
+            RssClientConfig.RSS_CLIENT_RETRY_MAX_DEFAULT_VALUE)
+          val retryIntervalMax: Long = rssConf.getLong(
+            RssClientConfig.RSS_CLIENT_RETRY_INTERVAL_MAX,
+            RssClientConfig.RSS_CLIENT_RETRY_INTERVAL_MAX_DEFAULT_VALUE)
+          val shuffleReadClient: ShuffleReadClient =
+            ShuffleClientFactory.getInstance.createShuffleReadClient(
+              ShuffleClientFactory.newReadBuilder
+                .appId(appId)
+                .shuffleId(shuffleId)
+                .partitionId(partition)
+                .basePath(basePath)
+                .partitionNumPerRange(1)
+                .partitionNum(partitionNum)
+                .blockIdBitmap(partitionToExpectBlocks.get(partition))
+                .taskIdBitmap(taskIdBitmap)
+                .shuffleServerInfoList(shuffleServerInfoList)
+                .hadoopConf(hadoopConf)
+                .shuffleDataDistributionType(dataDistributionType)
+                .expectedTaskIdsBitmapFilterEnable(expectedTaskIdsBitmapFilterEnable)
+                .retryMax(retryMax)
+                .retryIntervalMax(retryIntervalMax)
+                .rssConf(rssConf))
+          val iterator: RssShuffleDataIterWrapper[K, C] =
+            new RssShuffleDataIterWrapper[K, C](
+              dependency,
+              shuffleReadClient,
+              readMetrics,
+              rssConf)
+          shuffleDataIterList.add(iterator)
+        }
+      }
+      if (!emptyPartitionIds.isEmpty) {
+        logInfo(s"")
+      }
+      iterators = shuffleDataIterList.iterator()
+      if (iterators.hasNext) {
+        currentIterator = iterators.next
+        iterators.remove()
+      }
+      context.addTaskCompletionListener(new TaskCompletionListener {
+        override def onTaskCompletion(context: TaskContext): Unit = {
+          context.taskMetrics.mergeShuffleReadMetrics()
+          if (currentIterator != null) {
+            currentIterator.cleanup()
+          }
+          if (iterators != null) {
+            while (iterators.hasNext) {
+              iterators.next().cleanup()
+            }
+          }
+        }
+      })
+    }
+
+    override def hasNext: Boolean = try {
+      if (currentIterator == null) return false
+      while (!currentIterator.hasNext) {
+        currentIterator.cleanup()
+        if (!iterators.hasNext) {
+          currentIterator = null
+          return false
+        }
+        currentIterator = iterators.next
+        iterators.remove()
+      }
+      currentIterator.hasNext
+    } catch {
+      case e: RssException =>
+        throw e
+    }
+
+    override def next: Product2[K, C] = {
+      val result: Product2[K, C] = currentIterator.next
+      result
+    }
+  }
+
+  private class UniffleInputStream(
+      iterator: MultiPartitionIterator[_, _],
+      shuffleId: Int,
+      startPartition: Int,
+      endPartition: Int)
+      extends java.io.InputStream {
+    private var byteBuffer: ByteBuffer = null
+
+    override def read(): Int = {
+      while (byteBuffer == null || !byteBuffer.hasRemaining()) {
+        if (!toNextBuffer()) {
+          return -1
+        }
+      }
+      byteBuffer.get() & 255
+    }
+
+    private def toNextBuffer(): Boolean = {
+      if (byteBuffer != null && byteBuffer.hasRemaining) {
+        return true
+      }
+      if (!iterator.hasNext) {
+        return false
+      }
+      val next = iterator.next()
+      if (next == null || next._2 == null) {
+        return false
+      }
+      this.byteBuffer = next._2.asInstanceOf[ByteBuffer]
+      true
+    }
+
+    override def read(arrayBytes: Array[Byte], off: Int, len: Int): Int = {
+      require(arrayBytes != null, "Propagated buffer must not be null")
+      require(off >= 0 && len >= 0 && len <= arrayBytes.length - off, "Invalid offset or length")
+
+      if (len == 0) {
+        return 0
+      }
+
+      var readBytes = 0
+      while (readBytes < len) {
+        while (byteBuffer == null || !byteBuffer.hasRemaining()) {
+          if (!this.toNextBuffer)
+            return if (readBytes > 0) readBytes else -1
+        }
+        val bytesToRead = Math.min(byteBuffer.remaining(), len - readBytes)
+        byteBuffer.get(arrayBytes, off + readBytes, bytesToRead)
+        readBytes += bytesToRead
+      }
+      readBytes
+    }
+  }
+}
+
+class RssShuffleDataIterWrapper[K, V](
+    dependency: ShuffleDependency[_, _, _],
+    readClient: ShuffleReadClient,
+    shuffleReadMetrics: ShuffleReadMetrics,
+    rssConf: RssConf)
+    extends RssShuffleDataIterator[K, V](
+      dependency.serializer,
+      readClient,
+      shuffleReadMetrics,
+      rssConf) {
+
+  override def createKVIterator(data: ByteBuffer): Iterator[Tuple2[AnyRef, AnyRef]] = {
+    val element = Tuple2.apply(data.remaining().asInstanceOf[AnyRef], data.asInstanceOf[AnyRef])
+    scala.Iterator.single(element)
+  }
+}

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleReader.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleReader.scala
@@ -89,7 +89,11 @@ class BlazeUniffleShuffleReader[K, C](
 
   override protected def readBlocks(): Iterator[(BlockId, InputStream)] = {
     val inputStream =
-      new UniffleInputStream(new MultiPartitionIterator[K, C](), shuffleId, startPartition, endPartition)
+      new UniffleInputStream(
+        new MultiPartitionIterator[K, C](),
+        shuffleId,
+        startPartition,
+        endPartition)
     Iterator.single((null, inputStream))
   }
 

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleWriter.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleWriter.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 The Blaze Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.blaze.shuffle.uniffle
+
+import com.thoughtworks.enableIf
+import org.apache.spark.internal.Logging
+import org.apache.spark.scheduler.MapStatus
+import org.apache.spark.shuffle.writer.RssShuffleWriter
+import org.apache.spark.shuffle.{ShuffleHandle, ShuffleWriteMetricsReporter}
+import org.apache.spark.sql.execution.blaze.shuffle.{BlazeRssShuffleWriterBase, RssPartitionWriterBase}
+
+class BlazeUniffleShuffleWriter[K, V, C](
+    rssShuffleWriter: RssShuffleWriter[K, V, C],
+    metrics: ShuffleWriteMetricsReporter)
+    extends BlazeRssShuffleWriterBase[K, V](metrics)
+    with Logging {
+
+  override def getRssPartitionWriter(
+      handle: ShuffleHandle,
+      mapId: Int,
+      metrics: ShuffleWriteMetricsReporter,
+      numPartitions: Int): RssPartitionWriterBase = {
+    new UnifflePartitionWriter(mapId, numPartitions, metrics, rssShuffleWriter)
+  }
+
+  @enableIf(
+    Seq("spark-3.2", "spark-3.3", "spark-3.4", "spark-3.5").contains(
+      System.getProperty("blaze.shim")))
+  override def getPartitionLengths(): Array[Long] = partitionLengths
+
+  private def waitAndCheckBlocksSend(): Unit = {
+    logInfo(s"Waiting all blocks sending to the remote shuffle servers...")
+    val method = rssShuffleWriter.getClass.getDeclaredMethod("internalCheckBlockSendResult")
+    method.setAccessible(true)
+    method.invoke(rssShuffleWriter)
+  }
+
+  override def stop(success: Boolean): Option[MapStatus] = {
+    waitAndCheckBlocksSend()
+    logInfo(s"Reporting the shuffle result...")
+    super.stop(success)
+    rssShuffleWriter.stop(success)
+  }
+}

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/UnifflePartitionWriter.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/UnifflePartitionWriter.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 The Blaze Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.blaze.shuffle.uniffle
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.shuffle.ShuffleWriteMetricsReporter
+import org.apache.spark.shuffle.writer.RssShuffleWriter
+import org.apache.spark.sql.execution.blaze.shuffle.RssPartitionWriterBase
+import org.apache.uniffle.common.ShuffleBlockInfo
+
+import java.nio.ByteBuffer
+
+class UnifflePartitionWriter[K, V, C](
+    mapId: Int,
+    numPartitions: Int,
+    metrics: ShuffleWriteMetricsReporter,
+    rssShuffleWriter: RssShuffleWriter[K, V, C])
+    extends RssPartitionWriterBase
+    with Logging {
+  private val mapStatusLengths: Array[Long] = Array.fill(numPartitions)(0L)
+  private val rssShuffleWriterPushBlocksMethod = {
+    val method = rssShuffleWriter.getClass.getDeclaredMethod(
+      "processShuffleBlockInfos",
+      classOf[java.util.List[ShuffleBlockInfo]])
+    method.setAccessible(true)
+    method
+  }
+
+  override def write(partitionId: Int, buffer: ByteBuffer): Unit = {
+    val bytes = new Array[Byte](buffer.limit())
+    buffer.get(bytes)
+    val bytesWritten = bytes.length
+
+    val bufferManager = rssShuffleWriter.getBufferManager
+    val shuffleBlockInfos = rssShuffleWriter.synchronized {
+      bufferManager.addPartitionData(partitionId, bytes)
+    }
+    if (shuffleBlockInfos != null && !shuffleBlockInfos.isEmpty) {
+      rssShuffleWriter.synchronized {
+        rssShuffleWriterPushBlocksMethod.invoke(rssShuffleWriter, shuffleBlockInfos)
+      }
+    }
+    mapStatusLengths(partitionId) += bytesWritten
+  }
+
+  override def flush(): Unit = {}
+
+  override def close(): Unit = {
+    val start = System.currentTimeMillis()
+    val bufferManager = rssShuffleWriter.getBufferManager
+    val restBlocks = bufferManager.clear()
+    if (restBlocks != null && !restBlocks.isEmpty) {
+      rssShuffleWriterPushBlocksMethod.invoke(rssShuffleWriter, restBlocks)
+    }
+    val writtenDurationMs = bufferManager.getWriteTime + (System.currentTimeMillis() - start)
+    metrics.incWriteTime(writtenDurationMs)
+  }
+
+  override def getPartitionLengthMap: Array[Long] = mapStatusLengths
+
+  override def stop(isSuccess: Boolean): Unit = {}
+}

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeRssShuffleWriterBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeRssShuffleWriterBase.scala
@@ -89,7 +89,7 @@ abstract class BlazeRssShuffleWriterBase[K, V](metrics: ShuffleWriteMetricsRepor
   }
 
   override def stop(success: Boolean): Option[MapStatus] = {
-    partitionWriters.foreach(_.stop())
+    partitionWriters.foreach(_.stop(success))
     super.stop(success)
   }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change

Uniffle is a high performance, general purpose remote shuffle service for distributed computing engines. It provides the ability to push shuffle data into centralized storage service, changing the shuffle style from "local file pull-like style" to "remote block push-like style". It brings in several advantages like supporting disaggregated storage deployment, super large shuffle jobs, and high elasticity. Currently it supports [Apache Spark](https://spark.apache.org/), [Apache Hadoop MapReduce](https://hadoop.apache.org/) and [Apache Tez](https://tez.apache.org/).

Based on the above advantages, uniffle has been used by several commercial companies. After intergrating with blaze, users' spark jobs will benefit greatly from storage-computation separation and vectorized execution.

# What changes are included in this PR?

Following the blaze's rss shuffle manager design to implement the writer + reader

# Are there any user-facing changes?

Yes. 
