### PR TITLE
Add support of building native with --features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,16 @@
       <properties>
         <releaseMode>release</releaseMode>
         <buildNativeWithRelease>true</buildNativeWithRelease>
+        <buildWithFeatures />
+      </properties>
+    </profile>
+
+    <profile>
+      <id>release-with-jemalloc-pprof</id>
+      <properties>
+        <releaseMode>release</releaseMode>
+        <buildNativeWithRelease>true</buildNativeWithRelease>
+        <buildWithFeatures>jemalloc-pprof</buildWithFeatures>
       </properties>
     </profile>
 
@@ -293,6 +303,7 @@
       <properties>
         <releaseMode>pre</releaseMode>
         <buildNativeWithRelease>false</buildNativeWithRelease>
+        <buildWithFeatures />
       </properties>
     </profile>
 

--- a/spark-extension/pom.xml
+++ b/spark-extension/pom.xml
@@ -109,6 +109,7 @@
               <arguments>
                 <argument>./build-native.sh</argument>
                 <argument>${releaseMode}</argument>
+                <argument>${buildWithFeatures}</argument>
               </arguments>
               <workingDirectory>../</workingDirectory>
               <useMavenLogger>true</useMavenLogger>


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change

In the PR #793, the partial features could be enabled by the rust cargo `--features `. This PR is to activate this by the maven side.

# What changes are included in this PR?

1. Introducing the `--features` as the one factor when detecting whether previous artifact could be reused to skip building native
2. Introduce the profile id of `release-with-jemalloc-pprof`

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
