### PR TITLE
Add support of memory profile

### DIFF
--- a/native-engine/blaze/src/http/memory_profiling.rs
+++ b/native-engine/blaze/src/http/memory_profiling.rs
@@ -1,0 +1,55 @@
+// Copyright 2022 The Blaze Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::{Error, ErrorKind};
+
+use log::error;
+use poem::{http::StatusCode, IntoResponse, Request, RouteMethod};
+
+use super::Handler;
+
+#[poem::handler]
+async fn jemalloc_pprof_handler(_: &Request) -> poem::Result<Vec<u8>> {
+    let pprof = dump_prof()
+        .await
+        .map_err(|e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
+    Ok(pprof)
+}
+
+async fn dump_prof() -> Result<Vec<u8>, Error> {
+    let mut prof_ctl = jemalloc_pprof::PROF_CTL.as_ref().unwrap().lock().await;
+    let pprof = prof_ctl.dump_pprof().map_err(|err| {
+        error!("Errors on jemalloc profile. err: {:?}", &err);
+        Error::new(ErrorKind::Other, err)
+    })?;
+    Ok(pprof)
+}
+
+pub struct MemoryProfileHandler {}
+
+impl Default for MemoryProfileHandler {
+    fn default() -> Self {
+        MemoryProfileHandler {}
+    }
+}
+
+impl Handler for MemoryProfileHandler {
+    fn get_route_method(&self) -> RouteMethod {
+        RouteMethod::new().get(jemalloc_pprof_handler)
+    }
+
+    fn get_route_path(&self) -> String {
+        "/debug/memory/profile".to_string()
+    }
+}

--- a/native-engine/blaze/src/http/mod.rs
+++ b/native-engine/blaze/src/http/mod.rs
@@ -1,3 +1,19 @@
+// Copyright 2022 The Blaze Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "jemalloc-pprof")]
+mod memory_profiling;
 #[cfg(feature = "jemalloc-pprof")]
 mod pprof;
 
@@ -80,6 +96,9 @@ impl HttpService {
         {
             use crate::http::pprof::PProfHandler;
             server.register_handler(PProfHandler::default());
+
+            use crate::http::memory_profiling::MemoryProfileHandler;
+            server.register_handler(MemoryProfileHandler::default());
         }
         server.start();
         Self

--- a/native-engine/blaze/src/http/pprof.rs
+++ b/native-engine/blaze/src/http/pprof.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Blaze Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::num::NonZeroI32;
 
 use log::error;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change

1. for memory profile to generate flamegraph

# What changes are included in this PR?

1. Introducing the api to get the memory profile data
2. Add the license header

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
