### PR TITLE
Fix the rootless-docker action failure when building the jar in github action

### DIFF
--- a/.github/workflows/build-ce7-releases.yml
+++ b/.github/workflows/build-ce7-releases.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-snapshot:
     name: Build Snapshot
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         sparkver: [spark-3.0, spark-3.1, spark-3.2, spark-3.3, spark-3.4, spark-3.5]


### PR DESCRIPTION

# Which issue does this PR close?

Try to fix the rootless-docker action failure when building the jar in github action

Closes #.

 # Rationale for this change

Refer to https://github.com/ScribeMD/rootless-docker/issues/401

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
