### PR TITLE
 .gitignore file add target-docker folder ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ spark-extension-shims-spark241kwaiae
 
 # exclude native engine build lib directory
 native-engine/_build
+
+/target-docker/


### PR DESCRIPTION
# Rationale for this change

After compiling with docker, there are over 6000 unversioned files displayed.
<img width="452" alt="image" src="https://github.com/user-attachments/assets/51255a89-253c-41c4-a215-bbf50e50efc0" />
