### PR TITLE
Support more native parquet scan metrics

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeConverters.scala
@@ -1205,8 +1205,9 @@ object NativeConverters extends Logging {
               .setReturnNullable(bound.nullable))
           aggBuilder.addAllChildren(convertedChildren.keys.asJava)
         } else {
-          throw new NotImplementedError(s"unsupported aggregate expression: (${e.getClass}) $e," +
-            s" set spark.blaze.enable.udaf true to enable")
+          throw new NotImplementedError(
+            s"unsupported aggregate expression: (${e.getClass}) $e," +
+              s" set spark.blaze.enable.udaf true to enable")
         }
 
     }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeHelper.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeHelper.scala
@@ -122,4 +122,40 @@ object NativeHelper extends Logging {
     }
     metrics
   }
+
+  private def getDefaultNativeFileMetrics(sc: SparkContext): Map[String, SQLMetric] = {
+    TreeMap(
+      "bytes_scanned" -> SQLMetrics.createSizeMetric(sc, "Native.bytes_scanned"),
+      "io_time" -> SQLMetrics.createNanoTimingMetric(sc, "Native.io_time"),
+      "io_time_getfs" -> SQLMetrics.createNanoTimingMetric(sc, "Native.io_time_getfs"),
+      // Parquet metrics
+      "predicate_evaluation_errors" -> SQLMetrics.createMetric(
+        sc,
+        "Native.predicate_evaluation_errors"),
+      "row_groups_matched_bloom_filter" -> SQLMetrics.createMetric(
+        sc,
+        "Native.row_groups_matched_bloom_filter"),
+      "row_groups_pruned_bloom_filter" -> SQLMetrics.createMetric(
+        sc,
+        "Native.row_groups_pruned_bloom_filter"),
+      "row_groups_matched_statistics" -> SQLMetrics.createMetric(
+        sc,
+        "Native.row_groups_matched_statistics"),
+      "row_groups_pruned_statistics" -> SQLMetrics.createMetric(
+        sc,
+        "Native.row_groups_pruned_statistics"),
+      "pushdown_rows_filtered" -> SQLMetrics.createMetric(sc, "Native.pushdown_rows_filtered"),
+      "pushdown_eval_time" -> SQLMetrics.createNanoTimingMetric(sc, "Native.pushdown_eval_time"),
+      "page_index_rows_filtered" -> SQLMetrics.createMetric(
+        sc,
+        "Native.page_index_rows_filtered"),
+      "page_index_eval_time" -> SQLMetrics.createNanoTimingMetric(
+        sc,
+        "Native.page_index_eval_time"))
+  }
+
+  def getNativeFileScanMetrics(sc: SparkContext): Map[String, SQLMetric] = TreeMap(
+    getDefaultNativeMetrics(sc)
+      .filterKeys(Set("stage_id", "output_rows", "elapsed_compute"))
+      .toSeq ++ getDefaultNativeFileMetrics(sc).toSeq: _*)
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/blaze/plan/NativeHiveTableScanBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/blaze/plan/NativeHiveTableScanBase.scala
@@ -15,7 +15,6 @@
  */
 package org.apache.spark.sql.hive.execution.blaze.plan
 
-import scala.collection.immutable.SortedMap
 import scala.collection.JavaConverters._
 import scala.collection.Seq
 
@@ -34,7 +33,6 @@ import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.FilePartition
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.metric.SQLMetric
-import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.hive.execution.HiveTableScanExec
 import org.apache.spark.sql.types.NullType
 import org.apache.spark.sql.types.StructField
@@ -49,19 +47,8 @@ abstract class NativeHiveTableScanBase(basedHiveScan: HiveTableScanExec)
     extends LeafExecNode
     with NativeSupports {
 
-  override lazy val metrics: Map[String, SQLMetric] = SortedMap[String, SQLMetric]() ++ Map(
-    NativeHelper
-      .getDefaultNativeMetrics(sparkContext)
-      .filterKeys(Set("stage_id", "output_rows", "elapsed_compute"))
-      .toSeq :+
-      ("predicate_evaluation_errors", SQLMetrics
-        .createMetric(sparkContext, "Native.predicate_evaluation_errors")) :+
-      ("row_groups_pruned", SQLMetrics
-        .createMetric(sparkContext, "Native.row_groups_pruned")) :+
-      ("bytes_scanned", SQLMetrics.createSizeMetric(sparkContext, "Native.bytes_scanned")) :+
-      ("io_time", SQLMetrics.createNanoTimingMetric(sparkContext, "Native.io_time")) :+
-      ("io_time_getfs", SQLMetrics
-        .createNanoTimingMetric(sparkContext, "Native.io_time_getfs")): _*)
+  override lazy val metrics: Map[String, SQLMetric] =
+    NativeHelper.getNativeFileScanMetrics(sparkContext)
 
   override val output: Seq[Attribute] = basedHiveScan.output
   override val outputPartitioning: Partitioning = basedHiveScan.outputPartitioning


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.
Add more parquet scan metrics as below:
row_groups_matched_bloom_filter
row_groups_pruned_bloom_filter
row_groups_matched_statistics
row_groups_pruned_statistics
pushdown_rows_filtered
pushdown_eval_time
page_index_rows_filtered
page_index_eval_time

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
