### PR TITLE
[BLAZE-877] Bump Celeborn version from 0.5.3 to 0.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <arrowVersion>16.0.0</arrowVersion>
     <protobufVersion>3.21.9</protobufVersion>
     <paimonVersion>1.0.0</paimonVersion>
-    <celebornVersion>0.5.3</celebornVersion>
+    <celebornVersion>0.5.4</celebornVersion>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
# Which issue does this PR close?

Closes #877.

 # Rationale for this change

Celeborn 0.5.4 is released, of which release note refers to [release_note_0.5.4](https://celeborn.apache.org/community/release_notes/release_note_0.5.4/).

# What changes are included in this PR?

Bump Celeborn version from 0.5.3 to 0.5.4 including bump the following commit:

- https://github.com/apache/celeborn/pull/3070

# Are there any user-facing changes?

No.