### PR TITLE
[BLAZE-879] Bump Spark from 3.5.4 to 3.5.5

### DIFF
--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -45,4 +45,4 @@ jobs:
     uses: ./.github/workflows/tpcds-reusable.yml
     with:
       sparkver: spark-3.5
-      sparkurl: https://archive.apache.org/dist/spark/spark-3.5.4/spark-3.5.4-bin-hadoop3.tgz
+      sparkurl: https://archive.apache.org/dist/spark/spark-3.5.5/spark-3.5.5-bin-hadoop3.tgz

--- a/pom.xml
+++ b/pom.xml
@@ -376,7 +376,7 @@
         <scalaLongVersion>2.12.15</scalaLongVersion>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
-        <sparkVersion>3.5.4</sparkVersion>
+        <sparkVersion>3.5.5</sparkVersion>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
# Which issue does this PR close?

Closes #879.

 # Rationale for this change

Spark 3.5.5 has been announced to release: [Spark 3.5.5 released](https://spark.apache.org/news/spark-3-5-5-released.html). The profile spark-3.5 could bump Spark from 3.5.4 to 3.5.5.

# What changes are included in this PR?

Bump Spark from 3.5.4 to 3.5.5.

# Are there any user-facing changes?

No.