### PR TITLE
[BLAZE-891] Remove stop interface of RssPartitionWriterBase

### DIFF
--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeBlockStoreShuffleReader.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeBlockStoreShuffleReader.scala
@@ -17,18 +17,11 @@ package org.apache.spark.sql.execution.blaze.shuffle
 
 import java.io.InputStream
 
-import org.apache.spark.MapOutputTracker
-import org.apache.spark.SparkEnv
-import org.apache.spark.TaskContext
-import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config
+import org.apache.spark.{MapOutputTracker, SparkEnv, TaskContext}
+import org.apache.spark.internal.{Logging, config}
 import org.apache.spark.io.CompressionCodec
-import org.apache.spark.shuffle.BaseShuffleHandle
-import org.apache.spark.shuffle.ShuffleReadMetricsReporter
-import org.apache.spark.storage.BlockId
-import org.apache.spark.storage.BlockManager
-import org.apache.spark.storage.BlockManagerId
-import org.apache.spark.storage.ShuffleBlockFetcherIterator
+import org.apache.spark.shuffle.{BaseShuffleHandle, ShuffleReadMetricsReporter}
+import org.apache.spark.storage.{BlockId, BlockManager, BlockManagerId, ShuffleBlockFetcherIterator}
 
 import com.thoughtworks.enableIf
 

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeRssShuffleManagerBase.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeRssShuffleManagerBase.scala
@@ -15,9 +15,7 @@
  */
 package org.apache.spark.sql.execution.blaze.shuffle
 
-import org.apache.spark.ShuffleDependency
-import org.apache.spark.SparkConf
-import org.apache.spark.TaskContext
+import org.apache.spark.{ShuffleDependency, SparkConf, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.shuffle._
 import org.apache.spark.sql.execution.blaze.shuffle.BlazeShuffleDependency.isArrowShuffle

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeShuffleManager.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeShuffleManager.scala
@@ -15,10 +15,7 @@
  */
 package org.apache.spark.sql.execution.blaze.shuffle
 
-import org.apache.spark.ShuffleDependency
-import org.apache.spark.SparkConf
-import org.apache.spark.SparkEnv
-import org.apache.spark.TaskContext
+import org.apache.spark.{ShuffleDependency, SparkConf, SparkEnv, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.shuffle._
 import org.apache.spark.shuffle.sort.SortShuffleManager

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleManager.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleManager.scala
@@ -18,21 +18,10 @@ package org.apache.spark.sql.execution.blaze.shuffle.celeborn
 import org.apache.celeborn.client.ShuffleClient
 import org.apache.celeborn.common.CelebornConf
 import org.apache.commons.lang3.reflect.FieldUtils
-import org.apache.spark.sql.execution.blaze.shuffle.BlazeRssShuffleManagerBase
-import org.apache.spark.SparkConf
-import org.apache.spark.TaskContext
-import org.apache.spark.shuffle.ShuffleBlockResolver
-import org.apache.spark.shuffle.ShuffleReader
-import org.apache.spark.shuffle.ShuffleWriter
-import org.apache.spark.sql.execution.blaze.shuffle.BlazeRssShuffleWriterBase
-import org.apache.spark.ShuffleDependency
-import org.apache.spark.shuffle.ShuffleHandle
-import org.apache.spark.shuffle.ShuffleReadMetricsReporter
-import org.apache.spark.shuffle.ShuffleWriteMetricsReporter
-import org.apache.spark.shuffle.celeborn.SparkShuffleManager
-import org.apache.spark.sql.execution.blaze.shuffle.BlazeRssShuffleReaderBase
-import org.apache.spark.shuffle.celeborn.CelebornShuffleHandle
-import org.apache.spark.shuffle.celeborn.ExecutorShuffleIdTracker
+import org.apache.spark.{ShuffleDependency, SparkConf, TaskContext}
+import org.apache.spark.shuffle._
+import org.apache.spark.shuffle.celeborn.{CelebornShuffleHandle, ExecutorShuffleIdTracker, SparkShuffleManager}
+import org.apache.spark.sql.execution.blaze.shuffle.{BlazeRssShuffleManagerBase, BlazeRssShuffleReaderBase, BlazeRssShuffleWriterBase}
 
 class BlazeCelebornShuffleManager(conf: SparkConf, isDriver: Boolean)
     extends BlazeRssShuffleManagerBase(conf) {
@@ -127,7 +116,8 @@ class BlazeCelebornShuffleManager(conf: SparkConf, isDriver: Boolean)
       context: TaskContext,
       metrics: ShuffleWriteMetricsReporter): BlazeRssShuffleWriterBase[K, V] = {
 
-    val celebornShuffleWriter = celebornShuffleManager.getWriter[K, V](handle, mapId, context, metrics)
+    val celebornShuffleWriter =
+      celebornShuffleManager.getWriter[K, V](handle, mapId, context, metrics)
     val shuffleClient = FieldUtils
       .readField(celebornShuffleManager, "shuffleClient", true)
       .asInstanceOf[ShuffleClient]

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleReader.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleReader.scala
@@ -15,41 +15,28 @@
  */
 package org.apache.spark.sql.execution.blaze.shuffle.celeborn
 
-import java.io.InputStream
-import java.io.IOException
+import java.io.{IOException, InputStream}
 import java.util
-import java.util.concurrent.{ConcurrentHashMap, TimeUnit, TimeoutException}
 import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.{ConcurrentHashMap, TimeUnit, TimeoutException}
 import scala.collection.JavaConverters._
+
 import org.apache.celeborn.client.ShuffleClient
 import org.apache.celeborn.client.ShuffleClientImpl.ReduceFileGroups
-import org.apache.celeborn.client.read.CelebornInputStream
-import org.apache.celeborn.client.read.MetricsCallback
+import org.apache.celeborn.client.read.{CelebornInputStream, MetricsCallback}
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.exception.CelebornIOException
-import org.apache.celeborn.common.exception.PartitionUnRetryAbleException
+import org.apache.celeborn.common.exception.{CelebornIOException, PartitionUnRetryAbleException}
 import org.apache.celeborn.common.network.client.TransportClient
 import org.apache.celeborn.common.network.protocol.TransportMessage
-import org.apache.celeborn.common.protocol.MessageType
-import org.apache.celeborn.common.protocol.PartitionLocation
-import org.apache.celeborn.common.protocol.PbOpenStreamList
-import org.apache.celeborn.common.protocol.PbOpenStreamListResponse
-import org.apache.celeborn.common.protocol.PbStreamHandler
+import org.apache.celeborn.common.protocol._
 import org.apache.celeborn.common.protocol.message.StatusCode
-import org.apache.celeborn.common.util.JavaUtils
-import org.apache.celeborn.common.util.ThreadUtils
-import org.apache.celeborn.common.util.Utils
-import org.apache.celeborn.common.util.ExceptionMaker
-import org.apache.spark.sql.execution.blaze.shuffle.BlazeRssShuffleReaderBase
+import org.apache.celeborn.common.util.{ExceptionMaker, JavaUtils, ThreadUtils, Utils}
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
-import org.apache.spark.shuffle.celeborn.CelebornShuffleHandle
-import org.apache.spark.shuffle.ShuffleReadMetricsReporter
-import org.apache.spark.shuffle.celeborn.CelebornShuffleReader
-import org.apache.spark.shuffle.FetchFailedException
+import org.apache.spark.shuffle.{FetchFailedException, ShuffleReadMetricsReporter}
 import org.apache.spark.shuffle.celeborn.CelebornShuffleReader.streamCreatorPool
-import org.apache.spark.shuffle.celeborn.ExecutorShuffleIdTracker
-import org.apache.spark.shuffle.celeborn.SparkUtils
+import org.apache.spark.shuffle.celeborn.{CelebornShuffleHandle, CelebornShuffleReader, ExecutorShuffleIdTracker, SparkUtils}
+import org.apache.spark.sql.execution.blaze.shuffle.BlazeRssShuffleReaderBase
 import org.apache.spark.storage.BlockId
 import org.apache.spark.util.CompletionIterator
 

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleWriter.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleWriter.scala
@@ -16,14 +16,11 @@
 package org.apache.spark.sql.execution.blaze.shuffle.celeborn
 
 import org.apache.celeborn.client.ShuffleClient
-import org.apache.spark.shuffle.ShuffleHandle
-import org.apache.spark.shuffle.ShuffleWriteMetricsReporter
-import org.apache.spark.shuffle.celeborn.{CelebornShuffleHandle, ExecutorShuffleIdTracker, SparkUtils}
-import org.apache.spark.sql.execution.blaze.shuffle.BlazeRssShuffleWriterBase
-import org.apache.spark.sql.execution.blaze.shuffle.RssPartitionWriterBase
 import org.apache.spark.TaskContext
 import org.apache.spark.scheduler.MapStatus
-import org.apache.spark.shuffle.ShuffleWriter
+import org.apache.spark.shuffle.{ShuffleHandle, ShuffleWriteMetricsReporter, ShuffleWriter}
+import org.apache.spark.shuffle.celeborn.{CelebornShuffleHandle, ExecutorShuffleIdTracker, SparkUtils}
+import org.apache.spark.sql.execution.blaze.shuffle.{BlazeRssShuffleWriterBase, RssPartitionWriterBase}
 
 import com.thoughtworks.enableIf
 

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleManager.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleManager.scala
@@ -18,9 +18,9 @@ package org.apache.spark.sql.execution.blaze.shuffle.uniffle
 import org.apache.spark.shuffle.reader.RssShuffleReader
 import org.apache.spark.shuffle.uniffle.RssShuffleHandleWrapper
 import org.apache.spark.shuffle.writer.RssShuffleWriter
-import org.apache.spark.shuffle.{RssShuffleHandle, RssShuffleManager, ShuffleBlockResolver, ShuffleHandle, ShuffleReadMetricsReporter, ShuffleReader, ShuffleWriteMetricsReporter, ShuffleWriter}
-import org.apache.spark.{ShuffleDependency, SparkConf, TaskContext}
+import org.apache.spark.shuffle._
 import org.apache.spark.sql.execution.blaze.shuffle.{BlazeRssShuffleManagerBase, BlazeRssShuffleReaderBase, BlazeRssShuffleWriterBase}
+import org.apache.spark.{ShuffleDependency, SparkConf, TaskContext}
 
 class BlazeUniffleShuffleManager(conf: SparkConf, isDriver: Boolean)
     extends BlazeRssShuffleManagerBase(conf) {

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/UnifflePartitionWriter.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/UnifflePartitionWriter.scala
@@ -70,6 +70,4 @@ class UnifflePartitionWriter[K, V, C](
   }
 
   override def getPartitionLengthMap: Array[Long] = mapStatusLengths
-
-  override def stop(isSuccess: Boolean): Unit = {}
 }

--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeQuerySuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeQuerySuite.scala
@@ -19,7 +19,10 @@ import org.apache.spark.sql.Row
 
 import scala.collection.mutable.ArrayBuffer
 
-class BlazeQuerySuite extends org.apache.spark.sql.QueryTest with BaseBlazeSQLSuite with BlazeSQLTestHelper {
+class BlazeQuerySuite
+    extends org.apache.spark.sql.QueryTest
+    with BaseBlazeSQLSuite
+    with BlazeSQLTestHelper {
   import testImplicits._
 
   test("test partition path has url encoded character") {
@@ -158,18 +161,19 @@ class BlazeQuerySuite extends org.apache.spark.sql.QueryTest with BaseBlazeSQLSu
   test("SPARK-32864: Support ORC forced positional evolution with partitioned table") {
     Seq(true, false).foreach { forcePositionalEvolution =>
       withEnvConf(
-        BlazeConf.ORC_FORCE_POSITIONAL_EVOLUTION.key -> forcePositionalEvolution.toString,
-      ) {
+        BlazeConf.ORC_FORCE_POSITIONAL_EVOLUTION.key -> forcePositionalEvolution.toString) {
         withTempPath { f =>
           val path = f.getCanonicalPath
           Seq[(Integer, Integer, Integer)]((1, 2, 1), (3, 4, 2), (5, 6, 3), (null, null, 4))
-            .toDF("c1", "c2", "p").write.partitionBy("p").orc(path)
+            .toDF("c1", "c2", "p")
+            .write
+            .partitionBy("p")
+            .orc(path)
           val correctAnswer = Seq(Row(1, 2, 1), Row(3, 4, 2), Row(5, 6, 3), Row(null, null, 4))
           checkAnswer(spark.read.orc(path), correctAnswer)
 
           withTable("t") {
-            sql(
-              s"""
+            sql(s"""
                  |CREATE EXTERNAL TABLE t(c3 INT, c2 INT)
                  |USING ORC
                  |PARTITIONED BY (p int)

--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeSQLTestHelper.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeSQLTestHelper.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 The Blaze Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.spark.sql.blaze
 
 import org.apache.spark.SparkEnv
@@ -20,7 +35,8 @@ trait BlazeSQLTestHelper {
     (keys, values).zipped.foreach { (k, v) =>
       conf.set(k, v)
     }
-    try f finally {
+    try f
+    finally {
       keys.zip(currentValues).foreach {
         case (key, Some(value)) => conf.set(key, value)
         case (key, None) => conf.remove(key)

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeBlockStoreShuffleReaderBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeBlockStoreShuffleReaderBase.scala
@@ -15,23 +15,16 @@
  */
 package org.apache.spark.sql.execution.blaze.shuffle
 
-import java.io.FileInputStream
-import java.io.InputStream
-import java.nio.channels.Channels
-import java.nio.channels.ReadableByteChannel
+import java.io.{FileInputStream, InputStream}
 import java.nio.ByteBuffer
-
+import java.nio.channels.{Channels, ReadableByteChannel}
 import scala.annotation.tailrec
 
-import org.apache.commons.lang3.reflect.FieldUtils
-import org.apache.commons.lang3.reflect.MethodUtils
-import org.apache.spark.InterruptibleIterator
-import org.apache.spark.ShuffleDependency
-import org.apache.spark.TaskContext
+import org.apache.commons.lang3.reflect.{FieldUtils, MethodUtils}
+import org.apache.spark.{InterruptibleIterator, ShuffleDependency, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.network.util.LimitedInputStream
-import org.apache.spark.shuffle.BaseShuffleHandle
-import org.apache.spark.shuffle.ShuffleReader
+import org.apache.spark.shuffle.{BaseShuffleHandle, ShuffleReader}
 import org.apache.spark.storage.BlockId
 
 abstract class BlazeBlockStoreShuffleReaderBase[K, C](

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeShuffleDependency.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeShuffleDependency.scala
@@ -17,18 +17,12 @@ package org.apache.spark.sql.execution.blaze.shuffle
 
 import scala.reflect.ClassTag
 
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.types.StructType
-import org.apache.spark.Aggregator
-import org.apache.spark.Partitioner
-import org.apache.spark.ShuffleDependency
-import org.apache.spark.SparkEnv
-
+import org.apache.spark.{Aggregator, Partitioner, ShuffleDependency, SparkEnv}
 import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
-import org.apache.spark.shuffle.BaseShuffleHandle
-import org.apache.spark.shuffle.ShuffleHandle
-import org.apache.spark.shuffle.ShuffleWriteProcessor
+import org.apache.spark.shuffle.{BaseShuffleHandle, ShuffleHandle, ShuffleWriteProcessor}
+import org.apache.spark.sql.types.StructType
 
 class BlazeShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     @transient private val _rdd: RDD[_ <: Product2[K, V]],

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeShuffleWriterBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeShuffleWriterBase.scala
@@ -15,26 +15,15 @@
  */
 package org.apache.spark.sql.execution.blaze.shuffle
 
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
-import java.nio.file.Files
-import java.nio.file.Paths
+import java.nio.{ByteBuffer, ByteOrder}
+import java.nio.file.{Files, Paths}
 
-import org.apache.spark.Partition
-import org.apache.spark.ShuffleDependency
-import org.apache.spark.SparkEnv
-import org.apache.spark.TaskContext
-import org.blaze.protobuf.PhysicalPlanNode
-import org.blaze.protobuf.ShuffleWriterExecNode
-
+import org.apache.spark.{Partition, ShuffleDependency, SparkEnv, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.MapStatus
-import org.apache.spark.shuffle.IndexShuffleBlockResolver
-import org.apache.spark.shuffle.ShuffleWriteMetricsReporter
-import org.apache.spark.shuffle.ShuffleWriter
-import org.apache.spark.sql.blaze.NativeHelper
-import org.apache.spark.sql.blaze.NativeRDD
-import org.apache.spark.sql.blaze.Shims
+import org.apache.spark.shuffle.{IndexShuffleBlockResolver, ShuffleWriteMetricsReporter, ShuffleWriter}
+import org.apache.spark.sql.blaze.{NativeHelper, NativeRDD, Shims}
+import org.blaze.protobuf.{PhysicalPlanNode, ShuffleWriterExecNode}
 
 abstract class BlazeShuffleWriterBase[K, V](metrics: ShuffleWriteMetricsReporter)
     extends ShuffleWriter[K, V]

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/RssPartitionWriterBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/RssPartitionWriterBase.scala
@@ -22,5 +22,4 @@ trait RssPartitionWriterBase {
   def flush(): Unit
   def close(): Unit
   def getPartitionLengthMap: Array[Long]
-  def stop(isSuccess: Boolean): Unit
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #891.

 # Rationale for this change

`RssPartitionWriterBase` has `close` and `stop` conflicted interfaces.

# What changes are included in this PR?

Remove `stop` interface of `RssPartitionWriterBase`.

# Are there any user-facing changes?

No.