### PR TITLE
[BLAZE-895] Bump Paimon from 1.0.0 to 1.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <arrowVersion>16.0.0</arrowVersion>
     <protobufVersion>3.21.9</protobufVersion>
-    <paimonVersion>1.0.0</paimonVersion>
+    <paimonVersion>1.0.1</paimonVersion>
     <celebornVersion>0.5.4</celebornVersion>
   </properties>
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #895.

 # Rationale for this change

Paimon 1.0.1 has been announced to release: [Paimon 1.0.1 released](https://paimon.apache.org/releases/1.0.1).

# What changes are included in this PR?

Bump Paimon from 1.0.0 to 1.0.1.

# Are there any user-facing changes?

No.