### PR TITLE
[BLAZE-905] Bytes written should increment in UnifflePartitionWriter#write

### DIFF
--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/UnifflePartitionWriter.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/UnifflePartitionWriter.scala
@@ -53,6 +53,7 @@ class UnifflePartitionWriter[K, V, C](
         rssShuffleWriterPushBlocksMethod.invoke(rssShuffleWriter, shuffleBlockInfos)
       }
     }
+    metrics.incBytesWritten(bytesWritten)
     mapStatusLengths(partitionId) += bytesWritten
   }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #905.

 # Rationale for this change

`UnifflePartitionWriter#write` does not increment bytes written.

# What changes are included in this PR?

Bytes written should increment in `UnifflePartitionWriter#write`.

# Are there any user-facing changes?

No.
