### PR TITLE
fix inconsistent string to date casting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,7 +627,9 @@ checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-targets",
 ]
 
@@ -961,6 +963,7 @@ dependencies = [
  "blaze-jni-bridge",
  "byteorder",
  "bytes 1.10.1",
+ "chrono",
  "datafusion",
  "futures",
  "itertools 0.14.0",

--- a/native-engine/datafusion-ext-commons/Cargo.toml
+++ b/native-engine/datafusion-ext-commons/Cargo.toml
@@ -16,6 +16,7 @@ blaze-jni-bridge = { workspace = true }
 bigdecimal = "0.4.7"
 byteorder = "1.5.0"
 bytes = "1.10.1"
+chrono = "0.4.33"
 datafusion = { workspace = true }
 futures = "0.3"
 itertools = "0.14.0"

--- a/native-engine/datafusion-ext-functions/src/spark_dates.rs
+++ b/native-engine/datafusion-ext-functions/src/spark_dates.rs
@@ -12,21 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use arrow::compute::{date_part, DatePart};
+use arrow::{
+    compute::{date_part, DatePart},
+    datatypes::DataType,
+};
 use datafusion::{common::Result, physical_plan::ColumnarValue};
+use datafusion_ext_commons::arrow::cast::cast;
 
 pub fn spark_year(args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    let input = args[0].clone().into_array(1)?;
+    let input = cast(&args[0].clone().into_array(1)?, &DataType::Date32)?;
     Ok(ColumnarValue::Array(date_part(&input, DatePart::Year)?))
 }
 
 pub fn spark_month(args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    let input = args[0].clone().into_array(1)?;
+    let input = cast(&args[0].clone().into_array(1)?, &DataType::Date32)?;
     Ok(ColumnarValue::Array(date_part(&input, DatePart::Month)?))
 }
 
 pub fn spark_day(args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    let input = args[0].clone().into_array(1)?;
+    let input = cast(&args[0].clone().into_array(1)?, &DataType::Date32)?;
     Ok(ColumnarValue::Array(date_part(&input, DatePart::Day)?))
 }
 


### PR DESCRIPTION
in current implementation, `cast('2025-01' as date)` returns null, while spark returns '2025-01-01'. we should keep the same behaviour with spark.
