### PR TITLE
feat: Activate symbolize feature for heap profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,6 +2886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa015c78eed2130951e22c58d2095849391e73817ab2e74f71b0b9f63dd8416"
 dependencies = [
  "anyhow",
+ "backtrace",
  "flate2",
  "num",
  "paste",

--- a/native-engine/blaze/Cargo.toml
+++ b/native-engine/blaze/Cargo.toml
@@ -52,6 +52,7 @@ features = ["disable_initial_exec_tls"]
 
 [dependencies.jemalloc_pprof]
 version = "0.7.0"
+features = ["symbolize"]
 optional = true
 
 [dependencies.pprof]


### PR DESCRIPTION
# Which issue does this PR close?

Follow up the PR of #69 

 # Rationale for this change

Before this PR, the heap profile dump lacks the code stack, that means the concrete code line/name won't be shown in the flamegrah. So let's activate this

# What changes are included in this PR?

 Activate symbolize feature

# Are there any user-facing changes?

Noop
