### PR TITLE
Avoid warning log `No such type of ValidateSparkPlan`

### DIFF
--- a/spark-extension-shims-spark3/src/main/java/org/apache/spark/sql/blaze/ValidateSparkPlanInjector.java
+++ b/spark-extension-shims-spark3/src/main/java/org/apache/spark/sql/blaze/ValidateSparkPlanInjector.java
@@ -44,7 +44,7 @@ public class ValidateSparkPlanInjector {
                     .make()
                     .load(ClassLoader.getSystemClassLoader(), ClassLoadingStrategy.Default.INJECTION);
         } catch (TypePool.Resolution.NoSuchTypeException e) {
-            logger.warn("No such type of ValidateSparkPlan", e);
+            logger.debug("No such type of ValidateSparkPlan", e);
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?



 # Rationale for this change

Some Spark versions do not have `ValidateSparkPlan`, and output warning log.


[SPARK-39551][SQL] Add AQE invalid plan check
https://issues.apache.org/jira/browse/SPARK-39551
Fix Version/s: 3.2.2, 3.3.1, 3.4.0

# What changes are included in this PR?


# Are there any user-facing changes?


