### PR TITLE
Scan parquet/orc config

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
@@ -121,6 +121,10 @@ object BlazeConverters extends Logging {
     SparkEnv.get.conf.getBoolean("spark.blaze.enable.local.table.scan", defaultValue = true)
   val enableDataWriting: Boolean =
     SparkEnv.get.conf.getBoolean("spark.blaze.enable.data.writing", defaultValue = false)
+  val enableScanParquet: Boolean =
+    SparkEnv.get.conf.getBoolean("spark.blaze.enable.scan.parquet", defaultValue = true)
+  val enableScanOrc: Boolean =
+    SparkEnv.get.conf.getBoolean("spark.blaze.enable.scan.orc", defaultValue = true)
 
   import org.apache.spark.sql.catalyst.plans._
   import org.apache.spark.sql.catalyst.optimizer._
@@ -328,10 +332,10 @@ object BlazeConverters extends Logging {
     logDebug(s"  tableIdentifier: ${tableIdentifier}")
     relation.fileFormat match {
       case p if p.getClass.getName.endsWith("ParquetFileFormat") =>
-        assert(SparkEnv.get.conf.getBoolean("spark.blaze.enable.scan.parquet", true))
+        assert(enableScanParquet)
         addRenameColumnsExec(Shims.get.createNativeParquetScanExec(exec))
       case p if p.getClass.getName.endsWith("OrcFileFormat") =>
-        assert(SparkEnv.get.conf.getBoolean("spark.blaze.enable.scan.orc", true))
+        assert(enableScanOrc)
         addRenameColumnsExec(Shims.get.createNativeOrcScanExec(exec))
       case _ => throw new NotImplementedError("Cannot convert non parquet/orc scan exec")
     }


### PR DESCRIPTION
# Which issue does this PR close?


Closes #.

 # Rationale for this change

FOLLOWUP https://github.com/kwai/blaze/pull/944

Avoid frequent parsing of configuration items

# What changes are included in this PR?


# Are there any user-facing changes?
