### PR TITLE
code refactoring and bug fixes

### DIFF
--- a/native-engine/blaze-jni-bridge/src/jni_bridge.rs
+++ b/native-engine/blaze-jni-bridge/src/jni_bridge.rs
@@ -252,11 +252,13 @@ macro_rules! jni_get_byte_array_len {
 macro_rules! jni_new_prim_array {
     ($ty:ident, $value:expr) => {{
         $crate::jni_bridge::THREAD_JNIENV.with(|env| {
+            let value = $value;
+            let value_len = value.len();
             $crate::jni_map_error_with_env!(
                 env,
-                paste::paste! {env.[<new_ $ty _array>]($value.len() as i32)}
+                paste::paste! {env.[<new_ $ty _array>](value_len as i32)}
                     .and_then(|array| {
-                        let value = unsafe { std::mem::transmute($value) };
+                        let value = unsafe { std::mem::transmute(value) };
                         paste::paste! {env.[<set_ $ty _array_region>](array, 0, value)}
                             .map(|_| array)
                     })
@@ -1164,8 +1166,6 @@ pub struct BlazeRssPartitionWriterBase<'a> {
     pub method_write_ret: ReturnType,
     pub method_flush: JMethodID,
     pub method_flush_ret: ReturnType,
-    pub method_close: JMethodID,
-    pub method_close_ret: ReturnType,
 }
 
 impl<'a> BlazeRssPartitionWriterBase<'_> {
@@ -1180,8 +1180,6 @@ impl<'a> BlazeRssPartitionWriterBase<'_> {
             method_write_ret: ReturnType::Primitive(Primitive::Void),
             method_flush: env.get_method_id(class, "flush", "()V")?,
             method_flush_ret: ReturnType::Primitive(Primitive::Void),
-            method_close: env.get_method_id(class, "close", "()V")?,
-            method_close_ret: ReturnType::Primitive(Primitive::Void),
         })
     }
 }
@@ -1215,6 +1213,8 @@ pub struct SparkUDAFWrapperContext<'a> {
     pub method_initialize_ret: ReturnType,
     pub method_resize: JMethodID,
     pub method_resize_ret: ReturnType,
+    pub method_numRecords: JMethodID,
+    pub method_numRecords_ret: ReturnType,
     pub method_update: JMethodID,
     pub method_update_ret: ReturnType,
     pub method_merge: JMethodID,
@@ -1250,6 +1250,12 @@ impl<'a> SparkUDAFWrapperContext<'a> {
                 "(Lorg/apache/spark/sql/blaze/BufferRowsColumn;I)V",
             )?,
             method_resize_ret: ReturnType::Primitive(Primitive::Void),
+            method_numRecords: env.get_method_id(
+                class,
+                "numRecords",
+                "(Lorg/apache/spark/sql/blaze/BufferRowsColumn;)I",
+            )?,
+            method_numRecords_ret: ReturnType::Primitive(Primitive::Int),
             method_update: env.get_method_id(
                 class,
                 "update",

--- a/native-engine/blaze-serde/proto/blaze.proto
+++ b/native-engine/blaze-serde/proto/blaze.proto
@@ -505,12 +505,15 @@ message ProjectionExecNode {
 }
 
 message UnionExecNode {
-  PhysicalPlanNode input = 1;
+  repeated UnionInput input = 1;
   Schema schema = 2;
   uint32 num_partitions = 3;
-  uint32 in_partition = 4;
-  uint32 num_children = 5;
-  uint32 current_child_index = 6;
+  uint32 cur_partition = 4;
+}
+
+message UnionInput {
+  PhysicalPlanNode input = 1;
+  uint32 partition = 2;
 }
 
 message ShuffleWriterExecNode {

--- a/native-engine/datafusion-ext-functions/src/spark_murmur3_hash.rs
+++ b/native-engine/datafusion-ext-functions/src/spark_murmur3_hash.rs
@@ -1,0 +1,97 @@
+// Copyright 2022 The Blaze Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use arrow::array::*;
+use datafusion::{common::Result, physical_plan::ColumnarValue};
+use datafusion_ext_commons::spark_hash::create_murmur3_hashes;
+
+/// implements org.apache.spark.sql.catalyst.expressions.Murmur3Hash
+pub fn spark_murmur3_hash(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    let len = args
+        .iter()
+        .map(|arg| match arg {
+            ColumnarValue::Array(array) => array.len(),
+            ColumnarValue::Scalar(_) => 1,
+        })
+        .max()
+        .unwrap_or(0);
+
+    let arrays = args
+        .iter()
+        .map(|arg| {
+            Ok(match arg {
+                ColumnarValue::Array(array) => array.clone(),
+                ColumnarValue::Scalar(scalar) => scalar.to_array_of_size(len)?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    // use identical seed as spark hash partition
+    let spark_murmur3_default_seed = 42i32;
+    let hashes = create_murmur3_hashes(len, &arrays, spark_murmur3_default_seed);
+
+    Ok(ColumnarValue::Array(Arc::new(Int32Array::from(hashes))))
+}
+
+#[cfg(test)]
+mod test {
+    use std::{error::Error, sync::Arc};
+
+    use arrow::array::{ArrayRef, Int32Array, Int64Array, StringArray};
+    use datafusion::logical_expr::ColumnarValue;
+
+    use crate::spark_murmur3_hash::spark_murmur3_hash;
+
+    #[test]
+    fn test_murmur3_hash_int64() -> Result<(), Box<dyn Error>> {
+        let result = spark_murmur3_hash(&vec![ColumnarValue::Array(Arc::new(Int64Array::from(
+            vec![Some(1), Some(0), Some(-1), Some(i64::MAX), Some(i64::MIN)],
+        )))])?
+        .into_array(5)?;
+
+        let expected = Int32Array::from(vec![
+            Some(-1712319331),
+            Some(-1670924195),
+            Some(-939490007),
+            Some(-1604625029),
+            Some(-853646085),
+        ]);
+        let expected: ArrayRef = Arc::new(expected);
+
+        assert_eq!(&result, &expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_murmur3_hash_string() -> Result<(), Box<dyn Error>> {
+        let result = spark_murmur3_hash(&vec![ColumnarValue::Array(Arc::new(
+            StringArray::from_iter_values(["hello", "bar", "", "😁", "天地"]),
+        ))])?
+        .into_array(5)?;
+
+        let expected = Int32Array::from(vec![
+            Some(-1008564952),
+            Some(-1808790533),
+            Some(142593372),
+            Some(885025535),
+            Some(-1899966402),
+        ]);
+        let expected: ArrayRef = Arc::new(expected);
+
+        assert_eq!(&result, &expected);
+        Ok(())
+    }
+}

--- a/native-engine/datafusion-ext-functions/src/spark_xxhash64.rs
+++ b/native-engine/datafusion-ext-functions/src/spark_xxhash64.rs
@@ -1,0 +1,107 @@
+// Copyright 2022 The Blaze Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use arrow::array::*;
+use datafusion::{
+    common::{Result, ScalarValue},
+    physical_plan::ColumnarValue,
+};
+use datafusion_ext_commons::spark_hash::create_xxhash64_hashes;
+
+/// implements org.apache.spark.sql.catalyst.expressions.XxHash64
+pub fn spark_xxhash64(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    let is_scalar = args
+        .iter()
+        .all(|arg| matches!(arg, ColumnarValue::Scalar(_)));
+    let len = args
+        .iter()
+        .map(|arg| match arg {
+            ColumnarValue::Array(array) => array.len(),
+            ColumnarValue::Scalar(_) => 1,
+        })
+        .max()
+        .unwrap_or(0);
+
+    let arrays = args
+        .iter()
+        .map(|arg| {
+            Ok(match arg {
+                ColumnarValue::Array(array) => array.clone(),
+                ColumnarValue::Scalar(scalar) => scalar.to_array_of_size(len)?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    // use identical seed as spark hash partition
+    let spark_xxhash64_default_seed = 42i64;
+    let hash_buffer = create_xxhash64_hashes(len, &arrays, spark_xxhash64_default_seed);
+
+    Ok(if is_scalar {
+        ColumnarValue::Scalar(ScalarValue::from(hash_buffer[0]))
+    } else {
+        ColumnarValue::Array(Arc::new(Int64Array::from(hash_buffer)))
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use std::{error::Error, sync::Arc};
+
+    use arrow::array::{ArrayRef, Int64Array, StringArray};
+    use datafusion::logical_expr::ColumnarValue;
+
+    use super::*;
+
+    #[test]
+    fn test_xxhash64_int64() -> Result<(), Box<dyn Error>> {
+        let result = spark_xxhash64(&vec![ColumnarValue::Array(Arc::new(Int64Array::from(
+            vec![Some(1), Some(0), Some(-1), Some(i64::MAX), Some(i64::MIN)],
+        )))])?
+        .into_array(5)?;
+
+        let expected = Int64Array::from(vec![
+            Some(-7001672635703045582),
+            Some(-5252525462095825812),
+            Some(3858142552250413010),
+            Some(-3246596055638297850),
+            Some(-8619748838626508300),
+        ]);
+        let expected: ArrayRef = Arc::new(expected);
+
+        assert_eq!(&result, &expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_xxhash64_string() -> Result<(), Box<dyn Error>> {
+        let result = spark_xxhash64(&vec![ColumnarValue::Array(Arc::new(
+            StringArray::from_iter_values(["hello", "bar", "", "😁", "天地"]),
+        ))])?
+        .into_array(5)?;
+
+        let expected = Int64Array::from(vec![
+            Some(-4367754540140381902),
+            Some(-1798770879548125814),
+            Some(-7444071767201028348),
+            Some(-6337236088984028203),
+            Some(-235771157374669727),
+        ]);
+        let expected: ArrayRef = Arc::new(expected);
+
+        assert_eq!(&result, &expected);
+        Ok(())
+    }
+}

--- a/native-engine/datafusion-ext-plans/src/agg_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/agg_exec.rs
@@ -15,10 +15,7 @@
 use std::{
     any::Any,
     fmt::{Debug, Formatter},
-    sync::{
-        atomic::{AtomicUsize, Ordering::SeqCst},
-        Arc,
-    },
+    sync::Arc,
 };
 
 use arrow::{
@@ -33,7 +30,6 @@ use datafusion::{
     physical_expr::EquivalenceProperties,
     physical_plan::{
         metrics::{ExecutionPlanMetricsSet, MetricsSet},
-        stream::RecordBatchStreamAdapter,
         DisplayAs, DisplayFormatType, ExecutionMode, ExecutionPlan, ExecutionPlanProperties,
         PlanProperties, SendableRecordBatchStream,
     },

--- a/native-engine/datafusion-ext-plans/src/broadcast_join_build_hash_map_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/broadcast_join_build_hash_map_exec.rs
@@ -205,6 +205,7 @@ pub fn execute_build_hash_map(
                 input_exec,
                 &keys,
                 Some(exec_ctx.execution_plan_metrics().clone()),
+                false, // do not record output metric
             );
             let mut sorted_stream =
                 sort_exec.execute(exec_ctx.partition_id(), exec_ctx.task_ctx())?;

--- a/native-engine/datafusion-ext-plans/src/broadcast_join_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/broadcast_join_exec.rs
@@ -417,6 +417,7 @@ async fn execute_join_with_smj_fallback(
                 create_record_batch_stream_exec(probed, exec_ctx.partition_id())?,
                 &join_params.right_keys,
                 Some(exec_ctx.execution_plan_metrics().clone()),
+                false, // do not record output metric
             ),
         ),
         JoinSide::Right => (
@@ -424,6 +425,7 @@ async fn execute_join_with_smj_fallback(
                 create_record_batch_stream_exec(probed, exec_ctx.partition_id())?,
                 &join_params.left_keys,
                 Some(exec_ctx.execution_plan_metrics().clone()),
+                false, // do not record output metric
             ),
             built_sorted,
         ),

--- a/native-engine/datafusion-ext-plans/src/shuffle/rss_sort_repartitioner.rs
+++ b/native-engine/datafusion-ext-plans/src/shuffle/rss_sort_repartitioner.rs
@@ -106,12 +106,7 @@ impl ShuffleRepartitioner for RssSortShuffleRepartitioner {
     }
 
     async fn shuffle_write(&self) -> Result<()> {
-        self.set_spillable(false);
-        let has_data = !self.data.lock().await.is_empty();
-        if has_data {
-            self.set_spillable(true);
-            self.force_spill().await?;
-        }
+        self.force_spill().await?;
         Ok(())
     }
 }

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/blaze/ShimsImpl.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/blaze/ShimsImpl.scala
@@ -111,9 +111,8 @@ import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.storage.FileSegment
-import org.blaze.{protobuf => pb}
 import org.apache.spark.sql.execution.blaze.shuffle.uniffle.BlazeUniffleShuffleManager
-import org.blaze.sparkver
+import org.blaze.{protobuf => pb, sparkver}
 
 class ShimsImpl extends Shims with Logging {
 
@@ -580,6 +579,7 @@ class ShimsImpl extends Shims with Logging {
           shuffledRDD.sparkContext,
           metrics,
           shuffledRDD.partitions,
+          shuffledRDD.partitioner,
           new OneToOneDependency(shuffledRDD) :: Nil,
           true,
           (partition, taskContext) => {
@@ -682,6 +682,7 @@ class ShimsImpl extends Shims with Logging {
           shuffledRDD.sparkContext,
           metrics,
           shuffledRDD.partitions,
+          shuffledRDD.partitioner,
           new OneToOneDependency(shuffledRDD) :: Nil,
           true,
           (partition, taskContext) => {
@@ -774,6 +775,7 @@ class ShimsImpl extends Shims with Logging {
           shuffledRDD.sparkContext,
           metrics,
           shuffledRDD.partitions,
+          shuffledRDD.partitioner,
           new OneToOneDependency(shuffledRDD) :: Nil,
           true,
           (partition, taskContext) => {

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeBlockStoreShuffleReader.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeBlockStoreShuffleReader.scala
@@ -35,7 +35,7 @@ class BlazeBlockStoreShuffleReader[K, C](
     extends BlazeBlockStoreShuffleReaderBase[K, C](handle, context)
     with Logging {
 
-  override def readBlocks(): Iterator[(BlockId, InputStream)] = {
+  override def readBlocks(): Iterator[InputStream] = {
     @sparkver("3.2 / 3.3 / 3.4 / 3.5")
     def fetchIterator = new ShuffleBlockFetcherIterator(
       context,
@@ -55,7 +55,7 @@ class BlazeBlockStoreShuffleReader[K, C](
       false, // checksums not supported
       "ChecksumAlgorithmsNotSupported",
       readMetrics,
-      fetchContinuousBlocksInBatch).toCompletionIterator
+      fetchContinuousBlocksInBatch).toCompletionIterator.map(_._2)
 
     @sparkver("3.0 / 3.1")
     def fetchIterator = new ShuffleBlockFetcherIterator(
@@ -72,7 +72,7 @@ class BlazeBlockStoreShuffleReader[K, C](
       SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT),
       SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT_MEMORY),
       readMetrics,
-      fetchContinuousBlocksInBatch).toCompletionIterator
+      fetchContinuousBlocksInBatch).toCompletionIterator.map(_._2)
 
     fetchIterator
   }

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleReader.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleReader.scala
@@ -15,32 +15,29 @@
  */
 package org.apache.spark.sql.execution.blaze.shuffle.celeborn
 
-import java.io.{InputStream, IOException}
-import java.util
-import java.util.concurrent.atomic.AtomicReference
-import java.util.concurrent.{ConcurrentHashMap, TimeoutException, TimeUnit}
+import java.io.InputStream
+import java.io.OutputStream
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.nio.ByteBuffer
 
-import scala.collection.JavaConverters._
+import scala.reflect.ClassTag
 
-import org.apache.celeborn.client.ShuffleClient
-import org.apache.celeborn.client.ShuffleClientImpl.ReduceFileGroups
-import org.apache.celeborn.client.read.{CelebornInputStream, MetricsCallback}
+import org.apache.celeborn.client.read.CelebornInputStream
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.exception.{CelebornIOException, PartitionUnRetryAbleException}
-import org.apache.celeborn.common.network.client.TransportClient
-import org.apache.celeborn.common.network.protocol.TransportMessage
-import org.apache.celeborn.common.protocol._
-import org.apache.celeborn.common.protocol.message.StatusCode
-import org.apache.celeborn.common.util.{ExceptionMaker, JavaUtils, ThreadUtils, Utils}
 import org.apache.commons.lang3.reflect.FieldUtils
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
-import org.apache.spark.shuffle.{FetchFailedException, ShuffleReadMetricsReporter}
-import org.apache.spark.shuffle.celeborn.CelebornShuffleReader.streamCreatorPool
-import org.apache.spark.shuffle.celeborn.{CelebornShuffleHandle, CelebornShuffleReader, ExecutorShuffleIdTracker, SparkUtils}
+import org.apache.spark.shuffle.ShuffleReadMetricsReporter
+import org.apache.spark.shuffle.celeborn.CelebornShuffleHandle
+import org.apache.spark.shuffle.celeborn.CelebornShuffleReader
+import org.apache.spark.shuffle.celeborn.ExecutorShuffleIdTracker
 import org.apache.spark.sql.execution.blaze.shuffle.BlazeRssShuffleReaderBase
 import org.apache.spark.storage.BlockId
-import org.apache.spark.util.CompletionIterator
+import org.apache.spark.ShuffleDependency
+import org.apache.spark.serializer.DeserializationStream
+import org.apache.spark.serializer.SerializationStream
+import org.apache.spark.serializer.SerializerInstance
 
 class BlazeCelebornShuffleReader[K, C](
     conf: CelebornConf,
@@ -55,313 +52,83 @@ class BlazeCelebornShuffleReader[K, C](
     extends BlazeRssShuffleReaderBase[K, C](handle, context)
     with Logging {
 
-  private val shuffleClient = ShuffleClient.get(
-    handle.appUniqueId,
-    handle.lifecycleManagerHost,
-    handle.lifecycleManagerPort,
-    conf,
-    handle.userIdentifier,
-    handle.extension)
+  override protected def readBlocks(): Iterator[InputStream] = {
+    val reader = new CelebornShuffleReader[K, C](
+      handle,
+      startPartition,
+      endPartition,
+      startMapIndex.getOrElse(0),
+      endMapIndex.getOrElse(Int.MaxValue),
+      context,
+      conf,
+      BlazeCelebornShuffleReader.createBypassingIncRecordsReadMetrics(metrics),
+      shuffleIdTracker) {
 
-  private val exceptionRef = new AtomicReference[IOException]
-  private val throwsFetchFailure = handle.throwsFetchFailure
-  private val encodedAttemptId = BlazeCelebornShuffleManager.getEncodedAttemptNumber(context)
+      override def newSerializerInstance(dep: ShuffleDependency[K, _, C]): SerializerInstance = {
+        new SerializerInstance {
+          override def serialize[T: ClassTag](t: T): ByteBuffer =
+            throw new UnsupportedOperationException(
+              "BlazeCelebornShuffleReader.newSerializerInstance")
 
-  override protected def readBlocks(): Iterator[(BlockId, InputStream)] = {
+          override def deserialize[T: ClassTag](bytes: ByteBuffer): T =
+            throw new UnsupportedOperationException(
+              "BlazeCelebornShuffleReader.newSerializerInstance")
 
-    val startTime = System.currentTimeMillis()
-    val shuffleId = SparkUtils.celebornShuffleId(shuffleClient, handle, context, false)
-    shuffleIdTracker.track(handle.shuffleId, shuffleId)
-    logDebug(
-      s"get shuffleId $shuffleId for appShuffleId ${handle.shuffleId} attemptNum ${context.stageAttemptNumber()}")
+          override def deserialize[T: ClassTag](bytes: ByteBuffer, loader: ClassLoader): T =
+            throw new UnsupportedOperationException(
+              "BlazeCelebornShuffleReader.newSerializerInstance")
 
-    // Update the context task metrics for each record read.
-    val metricsCallback = new MetricsCallback {
-      override def incBytesRead(bytesWritten: Long): Unit = {
-        metrics.incRemoteBytesRead(bytesWritten)
-        metrics.incRemoteBlocksFetched(1)
-      }
+          override def serializeStream(s: OutputStream): SerializationStream =
+            throw new UnsupportedOperationException(
+              "BlazeCelebornShuffleReader.newSerializerInstance")
 
-      override def incReadTime(time: Long): Unit =
-        metrics.incFetchWaitTime(time)
-    }
+          override def deserializeStream(s: InputStream): DeserializationStream = {
+            new DeserializationStream {
+              override def asKeyValueIterator: Iterator[(Any, Any)] = Iterator.single((null, s))
 
-    if (streamCreatorPool == null) {
-      CelebornShuffleReader.synchronized {
-        if (streamCreatorPool == null) {
-          streamCreatorPool = ThreadUtils.newDaemonCachedThreadPool(
-            "celeborn-create-stream-thread",
-            conf.readStreamCreatorPoolThreads,
-            60)
-        }
-      }
-    }
+              override def readObject[T: ClassTag](): T =
+                throw new UnsupportedOperationException()
 
-    val fetchTimeoutMs = conf.clientFetchTimeoutMs
-    val localFetchEnabled = conf.enableReadLocalShuffleFile
-    val localHostAddress = Utils.localHostName(conf)
-    val shuffleKey = Utils.makeShuffleKey(handle.appUniqueId, shuffleId)
-    // startPartition is irrelevant
-    var fileGroups: ReduceFileGroups = null
-    try {
-      // startPartition is irrelevant
-      fileGroups = shuffleClient.updateFileGroup(shuffleId, startPartition)
-    } catch {
-      case ce @ (_: CelebornIOException | _: PartitionUnRetryAbleException) =>
-        // if a task is interrupted, should not report fetch failure
-        // if a task update file group timeout, should not report fetch failure
-        checkAndReportFetchFailureForUpdateFileGroupFailure(shuffleId, ce)
-      case e: Throwable => throw e
-    }
-
-    val batchOpenStreamStartTime = System.currentTimeMillis()
-    // host-port -> (TransportClient, PartitionLocation Array, PbOpenStreamList)
-    val workerRequestMap = new util.HashMap[
-      String,
-      (TransportClient, util.ArrayList[PartitionLocation], PbOpenStreamList.Builder)]()
-
-    var partCnt = 0
-
-    (startPartition until endPartition).foreach { partitionId =>
-      if (fileGroups.partitionGroups.containsKey(partitionId)) {
-        fileGroups.partitionGroups.get(partitionId).asScala.foreach { location =>
-          partCnt += 1
-          val hostPort = location.hostAndFetchPort
-          if (!workerRequestMap.containsKey(hostPort)) {
-            try {
-              val client = shuffleClient
-                .getDataClientFactory()
-                .createClient(location.getHost, location.getFetchPort)
-              val pbOpenStreamList = PbOpenStreamList.newBuilder()
-              pbOpenStreamList.setShuffleKey(shuffleKey)
-              workerRequestMap
-                .put(hostPort, (client, new util.ArrayList[PartitionLocation], pbOpenStreamList))
-            } catch {
-              case ex: Exception =>
-                shuffleClient.excludeFailedFetchLocation(location.hostAndFetchPort, ex)
-                logWarning(
-                  s"Failed to create client for $shuffleKey-$partitionId from host: ${location.hostAndFetchPort}. " +
-                    s"Shuffle reader will try its replica if exists.")
+              override def close(): Unit = s.close()
             }
-          }
-          workerRequestMap.get(hostPort) match {
-            case (_, locArr, pbOpenStreamListBuilder) =>
-              locArr.add(location)
-              pbOpenStreamListBuilder
-                .addFileName(location.getFileName)
-                .addStartIndex(startMapIndex.getOrElse(0))
-                .addEndIndex(endMapIndex.getOrElse(Int.MaxValue))
-              pbOpenStreamListBuilder.addReadLocalShuffle(
-                localFetchEnabled && location.getHost.equals(localHostAddress))
-            case _ =>
-              logDebug(s"Empty client for host ${hostPort}")
           }
         }
       }
     }
 
-    val locationStreamHandlerMap: ConcurrentHashMap[PartitionLocation, PbStreamHandler] =
-      JavaUtils.newConcurrentHashMap()
+    reader.read().map { kv =>
+      val celebornInputStream = kv._2.asInstanceOf[CelebornInputStream]
 
-    val futures = workerRequestMap
-      .values()
-      .asScala
-      .map { entry =>
-        streamCreatorPool.submit(new Runnable {
-          override def run(): Unit = {
-            val (client, locArr, pbOpenStreamListBuilder) = entry
-            val msg = new TransportMessage(
-              MessageType.BATCH_OPEN_STREAM,
-              pbOpenStreamListBuilder.build().toByteArray)
-            val pbOpenStreamListResponse =
-              try {
-                val response = client.sendRpcSync(msg.toByteBuffer, fetchTimeoutMs)
-                TransportMessage
-                  .fromByteBuffer(response)
-                  .getParsedPayload[PbOpenStreamListResponse]
-              } catch {
-                case _: Exception => null
-              }
-            if (pbOpenStreamListResponse != null) {
-              0 until locArr.size() foreach { idx =>
-                val streamHandlerOpt = pbOpenStreamListResponse.getStreamHandlerOptList.get(idx)
-                if (streamHandlerOpt.getStatus == StatusCode.SUCCESS.getValue) {
-                  locationStreamHandlerMap.put(locArr.get(idx), streamHandlerOpt.getStreamHandler)
-                }
-              }
-            }
-          }
-        })
-      }
-      .toList
-    // wait for all futures to complete
-    futures.foreach(f => f.get())
-    val end = System.currentTimeMillis()
-    // readTime should include batchOpenStreamTime, getShuffleId Rpc time and updateFileGroup Rpc time
-    metricsCallback.incReadTime(end - startTime)
-    logInfo(s"BatchOpenStream for $partCnt cost ${end - batchOpenStreamStartTime}ms")
-
-    val streams = JavaUtils.newConcurrentHashMap[Integer, CelebornInputStream]()
-
-    def createInputStream(partitionId: Int): Unit = {
-      val locations =
-        if (fileGroups.partitionGroups.containsKey(partitionId)) {
-          new util.ArrayList(fileGroups.partitionGroups.get(partitionId))
-        } else new util.ArrayList[PartitionLocation]()
-      val streamHandlers =
-        if (locations != null) {
-          val streamHandlerArr = new util.ArrayList[PbStreamHandler](locations.size())
-          locations.asScala.foreach { loc =>
-            streamHandlerArr.add(locationStreamHandlerMap.get(loc))
-          }
-          streamHandlerArr
-        } else null
-      if (exceptionRef.get() == null) {
-        try {
-          val inputStream = shuffleClient.readPartition(
-            shuffleId,
-            handle.shuffleId,
-            partitionId,
-            encodedAttemptId,
-            startMapIndex.getOrElse(0),
-            endMapIndex.getOrElse(Int.MaxValue),
-            if (throwsFetchFailure) {
-              new ExceptionMaker() {
-                override def makeFetchFailureException(
-                    appShuffleId: Int,
-                    shuffleId: Int,
-                    partitionId: Int,
-                    e: Exception): Exception = new FetchFailedException(
-                  null,
-                  appShuffleId,
-                  -1,
-                  -1,
-                  partitionId,
-                  s"Celeborn FetchFailure with shuffle id $appShuffleId/$shuffleId",
-                  e)
-              }
-            } else {
-              null
-            },
-            locations,
-            streamHandlers,
-            fileGroups.mapAttempts,
-            metricsCallback)
-
-          // force disable decompression because compression is skipped in shuffle writer
-          if (inputStream.totalPartitionsToRead() > 0) {
-            FieldUtils.writeField(
-              inputStream,
-              "shuffleCompressionEnabled",
-              Boolean.box(false).asInstanceOf[Object],
-              true)
-          }
-          streams.put(partitionId, inputStream)
-
-        } catch {
-          case e: IOException =>
-            logError(s"Exception caught when readPartition $partitionId!", e)
-            exceptionRef.compareAndSet(null, e)
-          case e: Throwable =>
-            logError(s"Non IOException caught when readPartition $partitionId!", e)
-            exceptionRef.compareAndSet(null, new CelebornIOException(e))
-        }
-      }
-    }
-
-    val inputStreamCreationWindow = conf.clientInputStreamCreationWindow
-    (startPartition until Math.min(startPartition + inputStreamCreationWindow, endPartition))
-      .foreach(partitionId => {
-        streamCreatorPool.submit(new Runnable {
-          override def run(): Unit = {
-            createInputStream(partitionId)
-          }
-        })
-      })
-
-    val recordIter = (startPartition until endPartition).iterator
-      .map(partitionId => {
-        if (handle.numMappers > 0) {
-          val startFetchWait = System.nanoTime()
-          var inputStream: CelebornInputStream = streams.get(partitionId)
-          var sleepCnt = 0L
-          while (inputStream == null) {
-            if (exceptionRef.get() != null) {
-              exceptionRef.get() match {
-                case ce @ (_: CelebornIOException | _: PartitionUnRetryAbleException) =>
-                  handleFetchExceptions(handle.shuffleId, shuffleId, partitionId, ce)
-                case e => throw e
-              }
-            }
-            if (sleepCnt == 0) {
-              logInfo(s"inputStream for partition: $partitionId is null, sleeping 5ms")
-            }
-            sleepCnt += 1
-            Thread.sleep(5)
-            inputStream = streams.get(partitionId)
-          }
-          if (sleepCnt > 0) {
-            logInfo(
-              s"inputStream for partition: $partitionId is not null, sleep $sleepCnt times for ${5 * sleepCnt} ms")
-          }
-          metricsCallback.incReadTime(
-            TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startFetchWait))
-          // ensure inputStream is closed when task completes
-          context.addTaskCompletionListener[Unit](_ => inputStream.close())
-
-          // Advance the input creation window
-          if (partitionId + inputStreamCreationWindow < endPartition) {
-            streamCreatorPool.submit(new Runnable {
-              override def run(): Unit = {
-                createInputStream(partitionId + inputStreamCreationWindow)
-              }
-            })
-          }
-
-          (partitionId, inputStream)
-        } else {
-          (partitionId, CelebornInputStream.empty())
-        }
-      })
-      .filter { case (_, inputStream) =>
-        inputStream != CelebornInputStream.empty()
-      }
-
-    CompletionIterator[(BlockId, InputStream), Iterator[(BlockId, InputStream)]](
-      recordIter.map(block => (null, block._2)), // blockId is not used
-      () => context.taskMetrics().mergeShuffleReadMetrics())
-  }
-
-  private def checkAndReportFetchFailureForUpdateFileGroupFailure(
-      celebornShuffleId: Int,
-      ce: Throwable): Unit = {
-    if (ce.getCause != null &&
-      (ce.getCause.isInstanceOf[InterruptedException] || ce.getCause
-        .isInstanceOf[TimeoutException])) {
-      logWarning(s"fetch shuffle ${celebornShuffleId} timeout or interrupt", ce)
-      throw ce
-    } else {
-      handleFetchExceptions(handle.shuffleId, celebornShuffleId, 0, ce)
+      // force disable decompression because compression is skipped in shuffle writer
+      FieldUtils.writeField(
+        celebornInputStream,
+        "shuffleCompressionEnabled",
+        Boolean.box(false).asInstanceOf[Object],
+        true)
+      celebornInputStream
     }
   }
+}
 
-  private def handleFetchExceptions(
-      appShuffleId: Int,
-      shuffleId: Int,
-      partitionId: Int,
-      ce: Throwable) = {
-    if (throwsFetchFailure &&
-      shuffleClient.reportShuffleFetchFailure(appShuffleId, shuffleId)) {
-      logWarning(s"Handle fetch exceptions for ${shuffleId}-${partitionId}", ce)
-      throw new FetchFailedException(
-        null,
-        appShuffleId,
-        -1,
-        -1,
-        partitionId,
-        SparkUtils.FETCH_FAILURE_ERROR_MSG + appShuffleId + "/" + shuffleId,
-        ce)
-    } else
-      throw ce
+object BlazeCelebornShuffleReader {
+  def createBypassingIncRecordsReadMetrics(
+      metrics: ShuffleReadMetricsReporter): ShuffleReadMetricsReporter = {
+
+    class MetricsInvocationHandler(metrics: ShuffleReadMetricsReporter)
+        extends InvocationHandler {
+      override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = {
+        method match {
+          case m if m.getName == "incRecordsRead" => null
+          case m => m.invoke(metrics, args: _*)
+        }
+      }
+    }
+
+    val classLoader = metrics.getClass.getClassLoader
+    val proxy = java.lang.reflect.Proxy.newProxyInstance(
+      classLoader,
+      Array(classOf[ShuffleReadMetricsReporter]),
+      new MetricsInvocationHandler(metrics))
+    proxy.asInstanceOf[ShuffleReadMetricsReporter]
   }
 }

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/CelebornPartitionWriter.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/CelebornPartitionWriter.scala
@@ -61,9 +61,11 @@ class CelebornPartitionWriter(
 
   override def flush(): Unit = {}
 
-  override def close(): Unit = {
+  override def close(success: Boolean): Unit = {
     val waitStartTime = System.nanoTime()
-    shuffleClient.mapperEnd(shuffleId, mapId, encodedAttemptId, numMappers)
+    if (success) {
+      shuffleClient.mapperEnd(shuffleId, mapId, encodedAttemptId, numMappers)
+    }
     shuffleClient.cleanup(shuffleId, mapId, encodedAttemptId)
     metrics.incWriteTime(System.nanoTime() - waitStartTime)
   }

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleReader.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleReader.scala
@@ -87,14 +87,14 @@ class BlazeUniffleShuffleReader[K, C](
   private val readMetrics: ShuffleReadMetrics =
     FieldUtils.readField(reader, "readMetrics", true).asInstanceOf[ShuffleReadMetrics]
 
-  override protected def readBlocks(): Iterator[(BlockId, InputStream)] = {
+  override protected def readBlocks(): Iterator[InputStream] = {
     val inputStream =
       new UniffleInputStream(
         new MultiPartitionIterator[K, C](),
         shuffleId,
         startPartition,
         endPartition)
-    Iterator.single((null, inputStream))
+    Iterator.single(inputStream)
   }
 
   private class MultiPartitionIterator[K, C] extends AbstractIterator[Product2[K, C]] {

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/UnifflePartitionWriter.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/UnifflePartitionWriter.scala
@@ -23,7 +23,6 @@ import org.apache.spark.shuffle.ShuffleWriteMetricsReporter
 import org.apache.spark.shuffle.writer.RssShuffleWriter
 import org.apache.spark.sql.execution.blaze.shuffle.RssPartitionWriterBase
 import org.apache.uniffle.common.ShuffleBlockInfo
-import java.nio.ByteBuffer
 
 class UnifflePartitionWriter[K, V, C](
     numPartitions: Int,
@@ -61,11 +60,11 @@ class UnifflePartitionWriter[K, V, C](
 
   override def flush(): Unit = {}
 
-  override def close(): Unit = {
+  override def close(success: Boolean): Unit = {
     val start = System.currentTimeMillis()
     val bufferManager = rssShuffleWriter.getBufferManager
     val restBlocks = bufferManager.clear()
-    if (restBlocks != null && !restBlocks.isEmpty) {
+    if (success && restBlocks != null && !restBlocks.isEmpty) {
       rssShuffleWriterPushBlocksMethod.invoke(rssShuffleWriter, restBlocks)
     }
     val writeDurationMs = bufferManager.getWriteTime + (System.currentTimeMillis() - start)

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeRDD.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeRDD.scala
@@ -24,6 +24,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.Dependency
 import org.apache.spark.Partition
+import org.apache.spark.Partitioner
 import org.apache.spark.SparkContext
 import org.apache.spark.TaskContext
 import org.blaze.protobuf.PhysicalPlanNode
@@ -32,6 +33,7 @@ class NativeRDD(
     @transient private val rddSparkContext: SparkContext,
     val metrics: MetricNode,
     private val rddPartitions: Array[Partition],
+    private val rddPartitioner: Option[Partitioner],
     private val rddDependencies: Seq[Dependency[_]],
     private val rddShuffleReadFull: Boolean,
     @transient private val nativePlan: (Partition, TaskContext) => PhysicalPlanNode,
@@ -56,6 +58,7 @@ class NativeRDD(
 
   override protected def getPartitions: Array[Partition] = rddPartitions
   override protected def getDependencies: Seq[Dependency[_]] = rddDependencies
+  override val partitioner: Option[Partitioner] = rddPartitioner
 
   override def compute(split: Partition, context: TaskContext): Iterator[InternalRow] = {
     val computingNativePlan = nativePlanWrapper.plan(split, context)

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/ConvertToNativeBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/ConvertToNativeBase.scala
@@ -67,6 +67,7 @@ abstract class ConvertToNativeBase(override val child: SparkPlan)
       sparkContext,
       nativeMetrics,
       rddPartitions = inputRDD.partitions,
+      rddPartitioner = inputRDD.partitioner,
       rddDependencies = new OneToOneDependency(inputRDD) :: Nil,
       Shims.get.getRDDShuffleReadFull(inputRDD),
       (partition, context) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeAggBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeAggBase.scala
@@ -172,6 +172,7 @@ abstract class NativeAggBase(
       sparkContext,
       nativeMetrics,
       rddPartitions = inputRDD.partitions,
+      rddPartitioner = inputRDD.partitioner,
       rddDependencies = new OneToOneDependency(inputRDD) :: Nil,
       inputRDD.isShuffleReadFull,
       (partition, taskContext) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeBroadcastExchangeBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeBroadcastExchangeBase.scala
@@ -162,6 +162,7 @@ abstract class NativeBroadcastExchangeBase(mode: BroadcastMode, override val chi
       sparkContext,
       nativeMetrics,
       partitions,
+      None,
       Nil,
       rddShuffleReadFull = true,
       (_, _) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeBroadcastJoinBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeBroadcastJoinBase.scala
@@ -144,6 +144,7 @@ abstract class NativeBroadcastJoinBase(
       sparkContext,
       nativeMetrics,
       probedRDD.partitions,
+      rddPartitioner = probedRDD.partitioner,
       rddDependencies = new OneToOneDependency(probedRDD) :: Nil,
       probedShuffleReadFull,
       (partition, context) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeExpandBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeExpandBase.scala
@@ -78,6 +78,7 @@ abstract class NativeExpandBase(
       sparkContext,
       nativeMetrics,
       rddPartitions = inputRDD.partitions,
+      rddPartitioner = inputRDD.partitioner,
       rddDependencies = new OneToOneDependency(inputRDD) :: Nil,
       inputRDD.isShuffleReadFull,
       (partition, taskContext) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeFilterBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeFilterBase.scala
@@ -95,6 +95,7 @@ abstract class NativeFilterBase(condition: Expression, override val child: Spark
       sparkContext,
       nativeMetrics,
       rddPartitions = inputRDD.partitions,
+      rddPartitioner = inputRDD.partitioner,
       rddDependencies = new OneToOneDependency(inputRDD) :: Nil,
       inputRDD.isShuffleReadFull,
       (partition, taskContext) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeGenerateBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeGenerateBase.scala
@@ -138,6 +138,7 @@ abstract class NativeGenerateBase(
       sparkContext,
       nativeMetrics,
       rddPartitions = inputRDD.partitions,
+      rddPartitioner = inputRDD.partitioner,
       rddDependencies = new OneToOneDependency(inputRDD) :: Nil,
       inputRDD.isShuffleReadFull,
       (partition, taskContext) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeGlobalLimitBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeGlobalLimitBase.scala
@@ -56,6 +56,7 @@ abstract class NativeGlobalLimitBase(limit: Long, override val child: SparkPlan)
       sparkContext,
       nativeMetrics,
       inputRDD.partitions,
+      inputRDD.partitioner,
       new OneToOneDependency(inputRDD) :: Nil,
       rddShuffleReadFull = false,
       (partition, taskContext) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeLocalLimitBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeLocalLimitBase.scala
@@ -53,6 +53,7 @@ abstract class NativeLocalLimitBase(limit: Long, override val child: SparkPlan)
       sparkContext,
       nativeMetrics,
       rddPartitions = inputRDD.partitions,
+      rddPartitioner = inputRDD.partitioner,
       rddDependencies = new OneToOneDependency(inputRDD) :: Nil,
       rddShuffleReadFull = false,
       (partition, taskContext) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeOrcScanBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeOrcScanBase.scala
@@ -56,6 +56,7 @@ abstract class NativeOrcScanBase(basedFileScan: FileSourceScanExec)
       sparkContext,
       nativeMetrics,
       partitions.asInstanceOf[Array[Partition]],
+      None,
       Nil,
       rddShuffleReadFull = true,
       (partition, _) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeParquetScanBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeParquetScanBase.scala
@@ -57,6 +57,7 @@ abstract class NativeParquetScanBase(basedFileScan: FileSourceScanExec)
       sparkContext,
       nativeMetrics,
       partitions.asInstanceOf[Array[Partition]],
+      None,
       Nil,
       rddShuffleReadFull = true,
       (partition, _context) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeParquetSinkBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeParquetSinkBase.scala
@@ -92,6 +92,7 @@ abstract class NativeParquetSinkBase(
       sparkSession.sparkContext,
       nativeMetrics,
       inputRDD.partitions,
+      inputRDD.partitioner,
       nativeDependencies,
       inputRDD.isShuffleReadFull,
       (partition, context) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeProjectBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeProjectBase.scala
@@ -76,6 +76,7 @@ abstract class NativeProjectBase(projectList: Seq[NamedExpression], override val
       sparkContext,
       nativeMetrics,
       rddPartitions = inputRDD.partitions,
+      rddPartitioner = inputRDD.partitioner,
       rddDependencies = new OneToOneDependency(inputRDD) :: Nil,
       inputRDD.isShuffleReadFull,
       (partition, taskContext) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeRenameColumnsBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeRenameColumnsBase.scala
@@ -58,6 +58,7 @@ abstract class NativeRenameColumnsBase(
       sparkContext,
       nativeMetrics,
       rddPartitions = inputRDD.partitions,
+      rddPartitioner = inputRDD.partitioner,
       rddDependencies = new OneToOneDependency(inputRDD) :: Nil,
       inputRDD.isShuffleReadFull,
       (partition, taskContext) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeShuffleExchangeBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeShuffleExchangeBase.scala
@@ -140,6 +140,7 @@ abstract class NativeShuffleExchangeBase(
       sparkContext,
       nativeMetrics,
       rddPartitions = rdd.partitions,
+      rddPartitioner = rdd.partitioner,
       rddDependencies = shuffleDependency :: Nil,
       Shims.get.getRDDShuffleReadFull(rdd),
       (partition, taskContext) => {
@@ -244,6 +245,7 @@ abstract class NativeShuffleExchangeBase(
       nativeInputRDD.sparkContext,
       nativeMetrics,
       nativeInputRDD.partitions,
+      nativeInputRDD.partitioner,
       new OneToOneDependency(nativeInputRDD) :: Nil,
       nativeInputRDD.isShuffleReadFull,
       (partition, taskContext) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeShuffledHashJoinBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeShuffledHashJoinBase.scala
@@ -92,10 +92,10 @@ abstract class NativeShuffledHashJoinBase(
     val nativeJoinType = this.nativeJoinType
     val nativeBuildSide = this.nativeBuildSide
 
-    val partitions = if (joinType != RightOuter) {
-      leftRDD.partitions
+    val (partitions, partitioner) = if (joinType != RightOuter) {
+      (leftRDD.partitions, leftRDD.partitioner)
     } else {
-      rightRDD.partitions
+      (rightRDD.partitions, rightRDD.partitioner)
     }
     val dependencies = Seq(new OneToOneDependency(leftRDD), new OneToOneDependency(rightRDD))
 
@@ -103,6 +103,7 @@ abstract class NativeShuffledHashJoinBase(
       sparkContext,
       nativeMetrics,
       partitions,
+      partitioner,
       dependencies,
       leftRDD.isShuffleReadFull && rightRDD.isShuffleReadFull,
       (partition, taskContext) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeSortBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeSortBase.scala
@@ -100,6 +100,7 @@ abstract class NativeSortBase(
       sparkContext,
       nativeMetrics,
       rddPartitions = inputRDD.partitions,
+      rddPartitioner = inputRDD.partitioner,
       rddDependencies = new OneToOneDependency(inputRDD) :: Nil,
       inputRDD.isShuffleReadFull,
       (partition, taskContext) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeSortMergeJoinBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeSortMergeJoinBase.scala
@@ -107,10 +107,10 @@ abstract class NativeSortMergeJoinBase(
     val nativeJoinOn = this.nativeJoinOn
     val nativeJoinType = this.nativeJoinType
 
-    val partitions = if (joinType != RightOuter) {
-      leftRDD.partitions
+    val (partitions, partitioner) = if (joinType != RightOuter) {
+      (leftRDD.partitions, leftRDD.partitioner)
     } else {
-      rightRDD.partitions
+      (rightRDD.partitions, rightRDD.partitioner)
     }
     val dependencies = Seq(new OneToOneDependency(leftRDD), new OneToOneDependency(rightRDD))
     val isShuffleReadFull = joinType match {
@@ -130,6 +130,7 @@ abstract class NativeSortMergeJoinBase(
       sparkContext,
       nativeMetrics,
       partitions,
+      partitioner,
       dependencies,
       isShuffleReadFull,
       (partition, taskContext) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeTakeOrderedBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeTakeOrderedBase.scala
@@ -130,6 +130,7 @@ abstract class NativeTakeOrderedBase(
       sparkContext,
       metrics = MetricNode(metrics, shuffledRDD.metrics :: Nil),
       shuffledRDD.partitions,
+      shuffledRDD.partitioner,
       new OneToOneDependency(shuffledRDD) :: Nil,
       rddShuffleReadFull = false,
       (_, taskContext) => {
@@ -181,6 +182,7 @@ abstract class NativePartialTakeOrderedBase(
       sparkContext,
       metrics = MetricNode(metrics, inputRDD.metrics :: Nil),
       inputRDD.partitions,
+      inputRDD.partitioner,
       new OneToOneDependency(inputRDD) :: Nil,
       rddShuffleReadFull = false,
       (partition, taskContext) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeUnionBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeUnionBase.scala
@@ -17,10 +17,12 @@ package org.apache.spark.sql.execution.blaze.plan
 
 import scala.collection.immutable.SortedMap
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.JavaConverters.asJavaIterableConverter
 
 import org.apache.spark.Dependency
 import org.apache.spark.Partition
 import org.apache.spark.RangeDependency
+import org.apache.spark.rdd.PartitionerAwareUnionRDDPartition
 import org.apache.spark.rdd.UnionPartition
 import org.apache.spark.sql.blaze.MetricNode
 import org.apache.spark.sql.blaze.NativeHelper
@@ -30,9 +32,11 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.SQLMetric
+import org.blaze.protobuf.EmptyPartitionsExecNode
 import org.blaze.protobuf.PhysicalPlanNode
 import org.blaze.protobuf.Schema
 import org.blaze.protobuf.UnionExecNode
+import org.blaze.protobuf.UnionInput
 
 abstract class NativeUnionBase(
     override val children: Seq[SparkPlan],
@@ -50,49 +54,63 @@ abstract class NativeUnionBase(
     val rdds = children.map(c => NativeHelper.executeNative(c))
     val nativeMetrics = MetricNode(metrics, rdds.map(_.metrics))
 
-    def unionedPartitions: Array[UnionPartition[InternalRow]] = {
-      val array = new Array[UnionPartition[InternalRow]](rdds.map(_.partitions.length).sum)
-      var pos = 0
-      for ((rdd, rddIndex) <- rdds.zipWithIndex; split <- rdd.partitions) {
-        array(pos) = new UnionPartition(pos, rdd, rddIndex, split.index)
-        pos += 1
-      }
-      array
-    }
-
-    def dependencies: Seq[Dependency[_]] = {
-      val deps = new ArrayBuffer[Dependency[_]]
-      var pos = 0
-      for (rdd <- rdds) {
-        deps += new RangeDependency(rdd, 0, pos, rdd.partitions.length)
-        pos += rdd.partitions.length
-      }
-      deps
-    }
+    val unionRDD = sparkContext.union(rdds)
+    val unionedPartitions = unionRDD.partitions
+    val unionedPartitioner = unionRDD.partitioner
+    val dependencies = unionRDD.dependencies
 
     new NativeRDD(
       sparkContext,
       nativeMetrics,
-      unionedPartitions.asInstanceOf[Array[Partition]],
+      unionedPartitions,
+      unionedPartitioner,
       dependencies,
       rdds.forall(_.isShuffleReadFull),
       (partition, taskContext) => {
-        val unionPartition = unionedPartitions(partition.index)
-        val inputPlan = rdds(unionPartition.parentRddIndex)
-          .nativePlan(unionPartition.parentPartition, taskContext)
+        val unionInputs = ArrayBuffer[(PhysicalPlanNode, Int)]()
+        partition match {
+          case p: UnionPartition[_] =>
+            val input = rdds(p.parentRddIndex).nativePlan(p.parentPartition, taskContext)
+            for (childIndex <- rdds.indices) {
+              if (childIndex == p.parentRddIndex) {
+                unionInputs.append((input, p.parentPartition.index))
+              } else {
+                unionInputs.append((nativeEmptyPartitionExec(1), 0))
+              }
+            }
+          case p: PartitionerAwareUnionRDDPartition =>
+            for ((rdd, partition) <- rdds.zip(p.parents)) {
+              unionInputs.append((rdd.nativePlan(partition, taskContext), partition.index))
+            }
+        }
 
         val union = UnionExecNode
           .newBuilder()
+          .addAllInput(unionInputs.map { case (input, partition) =>
+            UnionInput
+              .newBuilder()
+              .setInput(input)
+              .setPartition(partition)
+              .build()
+          }.asJava)
           .setNumPartitions(unionedPartitions.length)
-          .setInPartition(unionPartition.parentPartition.index)
-          .setNumChildren(rdds.length)
-          .setCurrentChildIndex(unionPartition.parentRddIndex)
+          .setCurPartition(partition.index)
           .setSchema(nativeSchema)
-          .setInput(inputPlan)
         PhysicalPlanNode.newBuilder().setUnion(union).build()
       },
       friendlyName = "NativeRDD.Union")
   }
+
+  private def nativeEmptyPartitionExec(numPartitions: Int) =
+    PhysicalPlanNode
+      .newBuilder()
+      .setEmptyPartitions(
+        EmptyPartitionsExecNode
+          .newBuilder()
+          .setSchema(nativeSchema)
+          .setNumPartitions(numPartitions)
+          .build())
+      .build()
 
   val nativeSchema: Schema = Util.getNativeSchema(output)
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeWindowBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeWindowBase.scala
@@ -188,6 +188,7 @@ abstract class NativeWindowBase(
       sparkContext,
       nativeMetrics,
       rddPartitions = inputRDD.partitions,
+      rddPartitioner = inputRDD.partitioner,
       rddDependencies = new OneToOneDependency(inputRDD) :: Nil,
       inputRDD.isShuffleReadFull,
       (partition, taskContext) => {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeBlockStoreShuffleReaderBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeBlockStoreShuffleReaderBase.scala
@@ -35,12 +35,10 @@ abstract class BlazeBlockStoreShuffleReaderBase[K, C](
   import BlazeBlockStoreShuffleReaderBase._
 
   protected val dep: ShuffleDependency[K, _, C] = handle.dependency
-  protected def readBlocks(): Iterator[(BlockId, InputStream)]
+  protected def readBlocks(): Iterator[InputStream]
 
   def readIpc(): Iterator[BlockObject] = {
-    val ipcIterator = readBlocks().map { case (_, inputStream) =>
-      createBlockObject(inputStream)
-    }
+    val ipcIterator = readBlocks().map(inputStream => createBlockObject(inputStream))
 
     // An interruptible iterator must be used here in order to support task cancellation
     new InterruptibleIterator[BlockObject](context, ipcIterator)

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeRssShuffleWriterBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeRssShuffleWriterBase.scala
@@ -47,6 +47,8 @@ abstract class BlazeRssShuffleWriterBase[K, V](metrics: ShuffleWriteMetricsRepor
 
     this.mapId = mapId
     this.rpw = getRssPartitionWriter(dep.shuffleHandle, mapId, metrics, numPartitions)
+    var success = false
+
     try {
       val jniResourceId = s"RssPartitionWriter:${UUID.randomUUID().toString}"
       JniBridge.resourcesMap.put(jniResourceId, rpw)
@@ -64,9 +66,10 @@ abstract class BlazeRssShuffleWriterBase[K, V](metrics: ShuffleWriteMetricsRepor
         nativeShuffleRDD.metrics,
         partition,
         Some(context))
-      assert(iterator.toArray.isEmpty)
+      success = iterator.toArray.isEmpty
+
     } finally {
-      rpw.close()
+      rpw.close(success)
     }
   }
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/RssPartitionWriterBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/RssPartitionWriterBase.scala
@@ -20,6 +20,6 @@ import java.nio.ByteBuffer
 trait RssPartitionWriterBase {
   def write(partitionId: Int, buffer: ByteBuffer): Unit
   def flush(): Unit
-  def close(): Unit
+  def close(success: Boolean): Unit
   def getPartitionLengthMap: Array[Long]
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/blaze/plan/NativePaimonTableScanExec.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/blaze/plan/NativePaimonTableScanExec.scala
@@ -77,6 +77,7 @@ case class NativePaimonTableScanExec(basedHiveScan: HiveTableScanExec)
       sparkContext,
       nativeMetrics,
       partitions.asInstanceOf[Array[Partition]],
+      None,
       Nil,
       rddShuffleReadFull = true,
       (partition, _) => {


### PR DESCRIPTION
fix rss writer: do not commit when native shuffle writing is not succeeded.
fix unsafe lifetime error in spark UDAF wrapper.
fix hash join and aggregate exec metrics when failed back to sorted
refactor UnionExec to support PartitionerAwareUnionRDD.
refactor celeborn reader: remove hard copied code from celeborn.