### PR TITLE
assert_eq key_rows sorted_row_indices

### DIFF
--- a/native-engine/datafusion-ext-plans/src/sort_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/sort_exec.rs
@@ -324,6 +324,7 @@ impl BufferedData {
         // sort into indices
         let num_rows = batch.num_rows().min(sorter.limit);
         let mut sorted_row_indices: Vec<u32> = (0..batch.num_rows() as u32).collect();
+        assert_eq!(key_rows.num_rows(), sorted_row_indices.len());
         sorted_row_indices
             .sort_unstable_by_key(|&row_idx| unsafe { key_rows.row_unchecked(row_idx as usize) });
         sorted_row_indices.truncate(num_rows);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

Current
```
# Problematic frame:
# C  [libc.so.6+0xca2c0]  __memcmp_evex_movbe+0x40
```
Fix
```
thread 'blaze-native-stage-0-part-0' panicked at native-engine/datafusion-ext-plans/src/sort_exec.rs:327:9:
assertion `left == right` failed
  left: 0
 right: 10000

Caused by: java.lang.RuntimeException: poll record batch error: Execution error: native execution panics: Execution error: Execution error: Execution error: output_with_sender[Sort] error: Execution error: assertion `left == right` failed
  left: 0
 right: 10000
	at org.apache.spark.sql.blaze.JniBridge.nextBatch(Native Method)
	at org.apache.spark.sql.blaze.BlazeCallNativeWrapper$$anon$1.hasNext(BlazeCallNativeWrapper.scala:83)
	at org.apache.spark.util.CompletionIterator.hasNext(CompletionIterator.scala:31)
	at scala.collection.Iterator.foreach(Iterator.scala:943)
	at scala.collection.Iterator.foreach$(Iterator.scala:943)
	at org.apache.spark.util.CompletionIterator.foreach(CompletionIterator.scala:25)
	at scala.collection.generic.Growable.$plus$plus$eq(Growable.scala:62)
```



# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
