### PR TITLE
[BLAZE-975] Fix duplicated shuffle data fetch under AQE Rebalance when using Uniffle in Blaze

### DIFF
--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleManager.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleManager.scala
@@ -64,6 +64,8 @@ class BlazeUniffleShuffleManager(conf: SparkConf, isDriver: Boolean)
     val reader =
       uniffleShuffleManager.getReader(
         rssHandleWrapper.rssShuffleHandleInfo,
+        startMapIndex,
+        endMapIndex,
         startPartition,
         endPartition,
         context,

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleReader.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleReader.scala
@@ -71,6 +71,8 @@ class BlazeUniffleShuffleReader[K, C](
     FieldUtils.readField(reader, "appId", true).asInstanceOf[String]
   private val shuffleId: Int =
     FieldUtils.readField(reader, "shuffleId", true).asInstanceOf[Int]
+  private val taskId: String =
+    FieldUtils.readField(reader, "taskId", true).asInstanceOf[String]
   private val basePath: String =
     FieldUtils.readField(reader, "basePath", true).asInstanceOf[String]
   private val partitionNum: Int =
@@ -87,6 +89,13 @@ class BlazeUniffleShuffleReader[K, C](
     FieldUtils.readField(reader, "readMetrics", true).asInstanceOf[ShuffleReadMetrics]
 
   override protected def readBlocks(): Iterator[InputStream] = {
+    logInfo(s"Shuffle read started: " +
+      s"appId=$appId" +
+      s", shuffleId=$shuffleId" +
+      s", taskId=$taskId" +
+      s", partitions: [$startPartition, $endPartition)" +
+      s", maps: [$startMapIndex, $endMapIndex)")
+
     val inputStream =
       new UniffleInputStream(
         new MultiPartitionIterator[K, C](),
@@ -107,6 +116,7 @@ class BlazeUniffleShuffleReader[K, C](
       val emptyPartitionIds = new util.ArrayList[Int]
       for (partition <- startPartition until endPartition) {
         if (partitionToExpectBlocks.get(partition).isEmpty) {
+          logInfo(s"$partition is empty partition")
           emptyPartitionIds.add(partition)
         } else {
           val shuffleServerInfoList: util.List[ShuffleServerInfo] =

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleReader.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleReader.scala
@@ -116,7 +116,7 @@ class BlazeUniffleShuffleReader[K, C](
       val emptyPartitionIds = new util.ArrayList[Int]
       for (partition <- startPartition until endPartition) {
         if (partitionToExpectBlocks.get(partition).isEmpty) {
-          logInfo(s"$partition is empty partition")
+          logInfo(s"$partition is a empty partition")
           emptyPartitionIds.add(partition)
         } else {
           val shuffleServerInfoList: util.List[ShuffleServerInfo] =


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #975 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

* By passing startMapIndex and endMapIndex when invoking uniffleShuffleManager.getReader, the correct blocks bitmap is constructed to guarantee the shuffle read task fetches the proper data.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* Add the passing of startMapIndex and endMapIndex parameters when invoking uniffleShuffleManager.getReader

* Add necessary log information for visibility

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
