### PR TITLE
[BLAZE-1010] Bump Paimon from 1.0.1 to 1.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <arrowVersion>16.0.0</arrowVersion>
     <protobufVersion>3.21.9</protobufVersion>
-    <paimonVersion>1.0.1</paimonVersion>
+    <paimonVersion>1.1.1</paimonVersion>
     <celebornVersion>0.5.4</celebornVersion>
   </properties>
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1010.

 # Rationale for this change

Paimon 1.1.1 has been announced to release: [Paimon 1.1.1 released](https://paimon.apache.org/releases/1.1.1).

# What changes are included in this PR?

Bump Paimon from 1.0.1 to 1.1.1.

# Are there any user-facing changes?

No.