### PR TITLE
[BLAZE-1056] Bump Celeborn version from 0.5.4 to 0.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <arrowVersion>16.0.0</arrowVersion>
     <protobufVersion>3.21.9</protobufVersion>
     <paimonVersion>1.1.1</paimonVersion>
-    <celebornVersion>0.5.4</celebornVersion>
+    <celebornVersion>0.6.0</celebornVersion>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1056.

 # Rationale for this change

Celeborn 0.6.0 is released, of which release note refers to [release_note_0.6.0](https://celeborn.apache.org/community/release_notes/release_note_0.6.0/).

# What changes are included in this PR?

Bump Celeborn version from 0.5.4 to 0.6.0 including bump the following commit:

- https://github.com/apache/celeborn/pull/3317

# Are there any user-facing changes?

No.