### PR TITLE
Improve rust log format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,7 @@ dependencies = [
  "blaze-jni-bridge",
  "blaze-serde",
  "bytesize",
+ "chrono",
  "datafusion",
  "datafusion-ext-commons",
  "datafusion-ext-plans",

--- a/native-engine/blaze/Cargo.toml
+++ b/native-engine/blaze/Cargo.toml
@@ -29,6 +29,7 @@ once_cell = { workspace = true }
 panic-message = { workspace = true }
 prost = { workspace = true }
 tokio = { workspace = true }
+chrono = { workspace = true }
 
 [dependencies.tikv-jemalloc-ctl]
 version = "0.6.0"

--- a/native-engine/blaze/src/logging.rs
+++ b/native-engine/blaze/src/logging.rs
@@ -14,6 +14,7 @@
 
 use std::{cell::Cell, time::Instant};
 
+use chrono::Local;
 use log::{Level, LevelFilter, Log, Metadata, Record};
 use once_cell::sync::OnceCell;
 
@@ -53,8 +54,11 @@ impl Log for SimpleLogger {
             let partition_id = THREAD_PARTITION_ID.get();
             let tid = THREAD_TID.get();
             eprintln!(
-                "(+{elapsed_sec:.3}s) [{}] (stage: {stage_id}, partition: {partition_id}, tid: {tid}) - {}",
+                "{} (+{elapsed_sec:.3}s) [{}] [{}:{}] (stage: {stage_id}, partition: {partition_id}, tid: {tid}) - {}",
+                Local::now().format("%Y-%m-%d %H:%M:%S%.3f"),
                 record.level(),
+                record.module_path().unwrap_or(""),
+                record.line().unwrap_or(0),
                 record.args()
             );
         }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->



# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Master
```
(+0.408s) [INFO] (stage: 0, partition: 0, tid: 0) - (partition=1) native execution finalizing
(+0.408s) [INFO] (stage: 0, partition: 0, tid: 0) - (partition=7) native execution finalizing
(+0.408s) [INFO] (stage: 0, partition: 0, tid: 0) - (partition=1) native execution finalized
(+0.408s) [INFO] (stage: 0, partition: 0, tid: 0) - (partition=7) native execution finalized
```

PR
```
2025-08-01 14:59:33.345 (+0.569s) [INFO] [blaze::rt:261] (stage: 0, partition: 0, tid: 0) - (partition=8) native execution finalizing
2025-08-01 14:59:33.345 (+0.569s) [INFO] [blaze::rt:269] (stage: 0, partition: 0, tid: 0) - (partition=8) native execution finalized
2025-08-01 14:59:33.345 (+0.570s) [INFO] [blaze::rt:269] (stage: 0, partition: 0, tid: 0) - (partition=9) native execution finalized
```