### PR TITLE
[BLAZE-1085] Make native log level configurable

### DIFF
--- a/native-engine/blaze-jni-bridge/src/conf.rs
+++ b/native-engine/blaze-jni-bridge/src/conf.rs
@@ -53,6 +53,7 @@ define_conf!(IntConf, SUGGESTED_BATCH_MEM_SIZE_KWAY_MERGE);
 define_conf!(BooleanConf, ORC_FORCE_POSITIONAL_EVOLUTION);
 define_conf!(IntConf, UDAF_FALLBACK_NUM_UDAFS_TRIGGER_SORT_AGG);
 define_conf!(BooleanConf, PARSE_JSON_ERROR_FALLBACK);
+define_conf!(StringConf, NATIVE_LOG_LEVEL);
 
 pub trait BooleanConf {
     fn key(&self) -> &'static str;

--- a/native-engine/blaze/src/exec.rs
+++ b/native-engine/blaze/src/exec.rs
@@ -31,7 +31,7 @@ use datafusion::{
 use datafusion_ext_plans::memmgr::MemManager;
 use jni::{
     JNIEnv,
-    objects::{JClass, JObject},
+    objects::{JClass, JObject, JString},
 };
 use once_cell::sync::OnceCell;
 
@@ -43,6 +43,7 @@ pub extern "system" fn Java_org_apache_spark_sql_blaze_JniBridge_callNative(
     env: JNIEnv,
     _: JClass,
     executor_memory_overhead: i64,
+    log_level: JString,
     native_wrapper: JObject,
 ) -> i64 {
     handle_unwinded_scope(|| -> Result<i64> {
@@ -61,7 +62,9 @@ pub extern "system" fn Java_org_apache_spark_sql_blaze_JniBridge_callNative(
         INIT.get_or_try_init(|| {
             // logging is not initialized at this moment
             eprintln!("------ initializing blaze native environment ------");
-            init_logging();
+            let log_level = env.get_string(log_level).map(|s| String::from(s)).unwrap();
+            eprintln!("initializing logging with level: {}", log_level);
+            init_logging(log_level.as_str());
 
             // init jni java classes
             log::info!("initializing JNI bridge");

--- a/spark-extension/src/main/java/org/apache/spark/sql/blaze/BlazeConf.java
+++ b/spark-extension/src/main/java/org/apache/spark/sql/blaze/BlazeConf.java
@@ -110,7 +110,9 @@ public enum BlazeConf {
     // batches in memory at the same time
     SUGGESTED_BATCH_MEM_SIZE_KWAY_MERGE("spark.blaze.suggested.batch.memSize.multiwayMerging", 1048576),
 
-    ORC_FORCE_POSITIONAL_EVOLUTION("spark.blaze.orc.force.positional.evolution", false);
+    ORC_FORCE_POSITIONAL_EVOLUTION("spark.blaze.orc.force.positional.evolution", false),
+
+    NATIVE_LOG_LEVEL("spark.blaze.native.log.level", "info");
 
     public final String key;
     private final Object defaultValue;

--- a/spark-extension/src/main/java/org/apache/spark/sql/blaze/JniBridge.java
+++ b/spark-extension/src/main/java/org/apache/spark/sql/blaze/JniBridge.java
@@ -36,7 +36,7 @@ import org.apache.spark.sql.blaze.memory.OnHeapSpillManager$;
 public class JniBridge {
     public static final ConcurrentHashMap<String, Object> resourcesMap = new ConcurrentHashMap<>();
 
-    public static native long callNative(long initNativeMemory, BlazeCallNativeWrapper wrapper);
+    public static native long callNative(long initNativeMemory, String logLevel, BlazeCallNativeWrapper wrapper);
 
     public static native boolean nextBatch(long ptr);
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeCallNativeWrapper.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeCallNativeWrapper.scala
@@ -64,7 +64,8 @@ case class BlazeCallNativeWrapper(
   private var batchCurRowIdx = 0
 
   logWarning(s"Start executing native plan")
-  private var nativeRuntimePtr = JniBridge.callNative(NativeHelper.nativeMemory, this)
+  private var nativeRuntimePtr =
+    JniBridge.callNative(NativeHelper.nativeMemory, BlazeConf.NATIVE_LOG_LEVEL.stringConf(), this)
 
   private lazy val rowIterator = new Iterator[InternalRow] {
     override def hasNext: Boolean = {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1085.

 # Rationale for this change

Currently, there is a lot of useless information in native info level log. I want to make the native log level configurable.

After this, test with log level conf:

<img width="1117" height="203" alt="image" src="https://github.com/user-attachments/assets/2e3dbd1a-3cee-4eac-93f1-adec1b391dc4" />

info log level output:
```
------ initializing blaze native environment ------
initializing logging with level: info
(+0.000s) [INFO] (stage: 0, partition: 0, tid: 0) - initializing JNI bridge
(+0.000s) [INFO] (stage: 0, partition: 0, tid: 0) - Initializing JavaClasses...
(+0.007s) [INFO] (stage: 0, partition: 0, tid: 0) - Initializing JavaClasses finished
(+0.007s) [INFO] (stage: 0, partition: 0, tid: 0) - initializing datafusion session
(+0.007s) [INFO] (stage: 0, partition: 0, tid: 0) - mem manager initialized with total memory: 9.6 EiB
(+0.014s) [INFO] (stage: 1, partition: 0, tid: 1) - start executing plan:
ProjectExec [spark_ext_function_Sha256(spark_ext_function_StringConcat(#7@0, #8@1)) AS #2, spark_ext_function_Sha256(spark_ext_function_StringConcat(#7@0, #8@1)) AS #3, spark_ext_function_Sha224(spark_ext_function_StringConcat(#7@0, #8@1)) AS #4, spark_ext_function_Sha384(spark_ext_function_StringConcat(#7@0, #8@1)) AS #5, spark_ext_function_Sha512(spark_ext_function_StringConcat(#7@0, #8@1)) AS #6], schema=[#2:Utf8;N, #3:Utf8;N, #4:Utf8;N, #5:Utf8;N, #6:Utf8;N]
  RenameColumnsExec: ["#7", "#8"], schema=[#7:Utf8;N, #8:Utf8;N]
......
```

error log level output:
```
------ initializing blaze native environment ------
initializing logging with level: error

Process finished with exit code 0
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

yes, add a new conf
