### PR TITLE
[BLAZE-1100] Fallback shuffle exchange when RoundRobinPartitioning with unsupported MapType

### DIFF
--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeQuerySuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeQuerySuite.scala
@@ -95,6 +95,104 @@ class BlazeQuerySuite
     }
   }
 
+  test("repartition over MapType") {
+    withTable("t_map") {
+      sql("create table t_map using parquet as select map('a', '1', 'b', '2') as data_map")
+      val df = sql("SELECT /*+ repartition(10) */ data_map FROM t_map")
+      checkAnswer(df, Seq(Row(Map("a" -> "1", "b" -> "2"))))
+    }
+  }
+
+  test("repartition over MapType with ArrayType") {
+    withTable("t_map_struct") {
+      sql("create table t_map_struct using parquet as select named_struct('m', map('x', '1')) as data_struct")
+      val df = sql("SELECT /*+ repartition(10) */ data_struct FROM t_map_struct")
+      checkAnswer(df, Seq(Row(Row(Map("x" -> "1")))))
+    }
+  }
+
+  test("repartition over ArrayType with MapType") {
+    withTable("t_array_map") {
+      sql(
+        """
+          |create table t_array_map using parquet as
+          |select array(map('k1', 1, 'k2', 2), map('k3', 3)) as array_of_map
+          |""".stripMargin)
+      val df = sql("SELECT /*+ repartition(10) */ array_of_map FROM t_array_map")
+      checkAnswer(df, Seq(Row(Seq(Map("k1" -> 1, "k2" -> 2), Map("k3" -> 3)))))
+    }
+  }
+
+  test("repartition over StructType with MapType") {
+    withTable("t_struct_map") {
+      sql(
+        """
+          |create table t_struct_map using parquet as
+          |select named_struct('id', 101, 'metrics', map('ctr', 0.123, 'cvr', 0.045)) as user_metrics
+          |""".stripMargin)
+      val df = sql("SELECT /*+ repartition(10) */ user_metrics FROM t_struct_map")
+      checkAnswer(df, Seq(Row(Row(101, Map("ctr" -> 0.123, "cvr" -> 0.045)))))
+    }
+  }
+
+  test("repartition over MapType with StructType") {
+    withTable("t_map_struct_value") {
+      sql(
+        """
+          |create table t_map_struct_value using parquet as
+          |select map(
+          |  'item1', named_struct('count', 3, 'score', 4.5),
+          |  'item2', named_struct('count', 7, 'score', 9.1)
+          |) as map_struct_value
+          |""".stripMargin)
+      val df = sql("SELECT /*+ repartition(10) */ map_struct_value FROM t_map_struct_value")
+      checkAnswer(df, Seq(Row(
+        Map(
+          "item1" -> Row(3, 4.5),
+          "item2" -> Row(7, 9.1)
+        )
+      )))
+    }
+  }
+
+  test("repartition over nested MapType") {
+    withTable("t_nested_map") {
+      sql(
+        """
+          |create table t_nested_map using parquet as
+          |select map(
+          |  'outer1', map('inner1', 10, 'inner2', 20),
+          |  'outer2', map('inner3', 30)
+          |) as nested_map
+          |""".stripMargin)
+      val df = sql("SELECT /*+ repartition(10) */ nested_map FROM t_nested_map")
+      checkAnswer(df, Seq(Row(
+        Map(
+          "outer1" -> Map("inner1" -> 10, "inner2" -> 20),
+          "outer2" -> Map("inner3" -> 30)
+        )
+      )))
+    }
+  }
+
+  test("repartition over ArrayType of StructType with MapType") {
+    withTable("t_array_struct_map") {
+      sql(
+        """
+          |create table t_array_struct_map using parquet as
+          |select array(
+          |  named_struct('name', 'user1', 'features', map('f1', 1.0, 'f2', 2.0)),
+          |  named_struct('name', 'user2', 'features', map('f3', 3.5))
+          |) as user_feature_array
+          |""".stripMargin)
+      val df = sql("SELECT /*+ repartition(10) */ user_feature_array FROM t_array_struct_map")
+      checkAnswer(df, Seq(Row(Seq(
+        Row("user1", Map("f1" -> 1.0f, "f2" -> 2.0f)),
+        Row("user2", Map("f3" -> 3.5f))
+      ))))
+    }
+  }
+
   test("log function with negative input") {
     withTable("t1") {
       sql("create table t1 using parquet as select -1 as c1")

--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeQuerySuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/blaze/BlazeQuerySuite.scala
@@ -105,7 +105,8 @@ class BlazeQuerySuite
 
   test("repartition over MapType with ArrayType") {
     withTable("t_map_struct") {
-      sql("create table t_map_struct using parquet as select named_struct('m', map('x', '1')) as data_struct")
+      sql(
+        "create table t_map_struct using parquet as select named_struct('m', map('x', '1')) as data_struct")
       val df = sql("SELECT /*+ repartition(10) */ data_struct FROM t_map_struct")
       checkAnswer(df, Seq(Row(Row(Map("x" -> "1")))))
     }
@@ -113,8 +114,7 @@ class BlazeQuerySuite
 
   test("repartition over ArrayType with MapType") {
     withTable("t_array_map") {
-      sql(
-        """
+      sql("""
           |create table t_array_map using parquet as
           |select array(map('k1', 1, 'k2', 2), map('k3', 3)) as array_of_map
           |""".stripMargin)
@@ -125,8 +125,7 @@ class BlazeQuerySuite
 
   test("repartition over StructType with MapType") {
     withTable("t_struct_map") {
-      sql(
-        """
+      sql("""
           |create table t_struct_map using parquet as
           |select named_struct('id', 101, 'metrics', map('ctr', 0.123, 'cvr', 0.045)) as user_metrics
           |""".stripMargin)
@@ -137,8 +136,7 @@ class BlazeQuerySuite
 
   test("repartition over MapType with StructType") {
     withTable("t_map_struct_value") {
-      sql(
-        """
+      sql("""
           |create table t_map_struct_value using parquet as
           |select map(
           |  'item1', named_struct('count', 3, 'score', 4.5),
@@ -146,19 +144,13 @@ class BlazeQuerySuite
           |) as map_struct_value
           |""".stripMargin)
       val df = sql("SELECT /*+ repartition(10) */ map_struct_value FROM t_map_struct_value")
-      checkAnswer(df, Seq(Row(
-        Map(
-          "item1" -> Row(3, 4.5),
-          "item2" -> Row(7, 9.1)
-        )
-      )))
+      checkAnswer(df, Seq(Row(Map("item1" -> Row(3, 4.5), "item2" -> Row(7, 9.1)))))
     }
   }
 
   test("repartition over nested MapType") {
     withTable("t_nested_map") {
-      sql(
-        """
+      sql("""
           |create table t_nested_map using parquet as
           |select map(
           |  'outer1', map('inner1', 10, 'inner2', 20),
@@ -166,19 +158,16 @@ class BlazeQuerySuite
           |) as nested_map
           |""".stripMargin)
       val df = sql("SELECT /*+ repartition(10) */ nested_map FROM t_nested_map")
-      checkAnswer(df, Seq(Row(
-        Map(
-          "outer1" -> Map("inner1" -> 10, "inner2" -> 20),
-          "outer2" -> Map("inner3" -> 30)
-        )
-      )))
+      checkAnswer(
+        df,
+        Seq(Row(
+          Map("outer1" -> Map("inner1" -> 10, "inner2" -> 20), "outer2" -> Map("inner3" -> 30)))))
     }
   }
 
   test("repartition over ArrayType of StructType with MapType") {
     withTable("t_array_struct_map") {
-      sql(
-        """
+      sql("""
           |create table t_array_struct_map using parquet as
           |select array(
           |  named_struct('name', 'user1', 'features', map('f1', 1.0, 'f2', 2.0)),
@@ -186,10 +175,11 @@ class BlazeQuerySuite
           |) as user_feature_array
           |""".stripMargin)
       val df = sql("SELECT /*+ repartition(10) */ user_feature_array FROM t_array_struct_map")
-      checkAnswer(df, Seq(Row(Seq(
-        Row("user1", Map("f1" -> 1.0f, "f2" -> 2.0f)),
-        Row("user2", Map("f3" -> 3.5f))
-      ))))
+      checkAnswer(
+        df,
+        Seq(
+          Row(
+            Seq(Row("user1", Map("f1" -> 1.0f, "f2" -> 2.0f)), Row("user2", Map("f3" -> 3.5f))))))
     }
   }
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.blaze.BlazeConvertStrategy.convertStrategyTag
 import org.apache.spark.sql.blaze.BlazeConvertStrategy.convertToNonNativeTag
 import org.apache.spark.sql.blaze.BlazeConvertStrategy.isNeverConvert
 import org.apache.spark.sql.blaze.BlazeConvertStrategy.joinSmallerSideTag
-import org.apache.spark.sql.blaze.NativeConverters.{scalarTypeSupported, StubExpr}
+import org.apache.spark.sql.blaze.NativeConverters.{roundRobinTypeSupported, scalarTypeSupported, StubExpr}
 import org.apache.spark.sql.catalyst.expressions.Alias
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
@@ -283,20 +283,29 @@ object BlazeConverters extends Logging {
     logDebug(s"Converting ShuffleExchangeExec: ${Shims.get.simpleStringWithNodeId(exec)}")
 
     assert(
-      exec.outputPartitioning.numPartitions == 1 || exec.outputPartitioning
-        .isInstanceOf[HashPartitioning] || exec.outputPartitioning
-        .isInstanceOf[RoundRobinPartitioning] || exec.outputPartitioning
+      outputPartitioning.numPartitions == 1 || outputPartitioning
+        .isInstanceOf[HashPartitioning] || outputPartitioning
+        .isInstanceOf[RoundRobinPartitioning] || outputPartitioning
         .isInstanceOf[RangePartitioning],
-      s"partitioning not supported: ${exec.outputPartitioning}")
+      s"partitioning not supported: $outputPartitioning")
 
-    if (exec.outputPartitioning.isInstanceOf[RangePartitioning]) {
-      val unsupportedOrderType = exec.outputPartitioning
-        .asInstanceOf[RangePartitioning]
-        .ordering
-        .find(e => !scalarTypeSupported(e.dataType))
-      assert(
-        unsupportedOrderType.isEmpty,
-        s"Unsupported order type in range partitioning: ${unsupportedOrderType.get}")
+    outputPartitioning match {
+      case partitioning: RangePartitioning =>
+        val unsupportedOrderType = partitioning
+          .ordering
+          .find(e => !scalarTypeSupported(e.dataType))
+        assert(
+          unsupportedOrderType.isEmpty,
+          s"Unsupported order type in range partitioning: ${unsupportedOrderType.get}")
+      case _: RoundRobinPartitioning =>
+        val unsupportedTypeInRR =
+          exec.output.find(attr => !roundRobinTypeSupported(attr.dataType))
+        assert(
+          unsupportedTypeInRR.isEmpty,
+          s"Unsupported data type in $outputPartitioning: attribute=${unsupportedTypeInRR.get.name}" +
+            s", dataType=${unsupportedTypeInRR.get.dataType}"
+        )
+      case _ =>
     }
 
     val convertedChild = outputPartitioning match {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
@@ -291,8 +291,7 @@ object BlazeConverters extends Logging {
 
     outputPartitioning match {
       case partitioning: RangePartitioning =>
-        val unsupportedOrderType = partitioning
-          .ordering
+        val unsupportedOrderType = partitioning.ordering
           .find(e => !scalarTypeSupported(e.dataType))
         assert(
           unsupportedOrderType.isEmpty,
@@ -303,8 +302,7 @@ object BlazeConverters extends Logging {
         assert(
           unsupportedTypeInRR.isEmpty,
           s"Unsupported data type in $outputPartitioning: attribute=${unsupportedTypeInRR.get.name}" +
-            s", dataType=${unsupportedTypeInRR.get.dataType}"
-        )
+            s", dataType=${unsupportedTypeInRR.get.dataType}")
       case _ =>
     }
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeConverters.scala
@@ -105,6 +105,13 @@ object NativeConverters extends Logging {
     }
   }
 
+  def roundRobinTypeSupported(dataType: DataType): Boolean = dataType match {
+    case MapType(_, _, _) => false
+    case ArrayType(elementType, _) => roundRobinTypeSupported(elementType)
+    case StructType(fields) => fields.forall(f => roundRobinTypeSupported(f.dataType))
+    case _ => true
+  }
+
   def convertDataType(sparkDataType: DataType): pb.ArrowType = {
     val arrowTypeBuilder = pb.ArrowType.newBuilder()
     sparkDataType match {


### PR DESCRIPTION
# Which issue does this PR close?
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/kwai/blaze/issues/1100

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Fallback shuffle exchange when RoundRobinPartitioning with unsupported MapType

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Added a check in `convertShuffleExchangeExec` to detect unsupported output types in `RoundRobinPartitioning` (currently `MapType`).
- Added test cases for various nested structures involving `MapType`, such as:
  - Top-level MapType
  - MapType with ArrayType
  - Struct with a MapType field
  - Array of Maps
  - Nested Map within Map
  - Map with Struct value
  - Array of Structs containing Maps

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
