### PR TITLE
[BLAZE-1104] Make Parquet maxOverReadSize and metadataCacheSize configurable

### DIFF
--- a/native-engine/blaze-jni-bridge/src/conf.rs
+++ b/native-engine/blaze-jni-bridge/src/conf.rs
@@ -41,6 +41,8 @@ define_conf!(IntConf, PARTIAL_AGG_SKIPPING_MIN_ROWS);
 define_conf!(BooleanConf, PARTIAL_AGG_SKIPPING_SKIP_SPILL);
 define_conf!(BooleanConf, PARQUET_ENABLE_PAGE_FILTERING);
 define_conf!(BooleanConf, PARQUET_ENABLE_BLOOM_FILTER);
+define_conf!(IntConf, PARQUET_MAX_OVER_READ_SIZE);
+define_conf!(IntConf, PARQUET_METADATA_CACHE_SIZE);
 define_conf!(StringConf, SPARK_IO_COMPRESSION_CODEC);
 define_conf!(IntConf, TOKIO_WORKER_THREADS_PER_CPU);
 define_conf!(IntConf, SPARK_TASK_CPUS);

--- a/native-engine/datafusion-ext-plans/src/parquet_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/parquet_exec.rs
@@ -22,7 +22,9 @@ use std::{any::Any, fmt, fmt::Formatter, ops::Range, pin::Pin, sync::Arc};
 use arrow::datatypes::SchemaRef;
 use arrow_schema::DataType;
 use blaze_jni_bridge::{
-    conf, conf::BooleanConf, conf::IntConf, jni_call_static, jni_new_global_ref, jni_new_string,
+    conf,
+    conf::{BooleanConf, IntConf},
+    jni_call_static, jni_new_global_ref, jni_new_string,
 };
 use bytes::Bytes;
 use datafusion::{
@@ -362,9 +364,7 @@ impl AsyncFileReader for ParquetFileReaderRef {
         &mut self,
         ranges: Vec<Range<usize>>,
     ) -> BoxFuture<'_, datafusion::parquet::errors::Result<Vec<Bytes>>> {
-        let max_over_read_size = conf::PARQUET_MAX_OVER_READ_SIZE
-          .value()
-          .unwrap_or(16384) as usize;
+        let max_over_read_size = conf::PARQUET_MAX_OVER_READ_SIZE.value().unwrap_or(16384) as usize;
         let num_ranges = ranges.len();
         let (sorted_range_indices, sorted_ranges): (Vec<usize>, Vec<Range<usize>>) = ranges
             .into_iter()

--- a/native-engine/datafusion-ext-plans/src/parquet_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/parquet_exec.rs
@@ -22,7 +22,7 @@ use std::{any::Any, fmt, fmt::Formatter, ops::Range, pin::Pin, sync::Arc};
 use arrow::datatypes::SchemaRef;
 use arrow_schema::DataType;
 use blaze_jni_bridge::{
-    conf, conf::BooleanConf, jni_call_static, jni_new_global_ref, jni_new_string,
+    conf, conf::BooleanConf, conf::IntConf, jni_call_static, jni_new_global_ref, jni_new_string,
 };
 use bytes::Bytes;
 use datafusion::{
@@ -362,7 +362,9 @@ impl AsyncFileReader for ParquetFileReaderRef {
         &mut self,
         ranges: Vec<Range<usize>>,
     ) -> BoxFuture<'_, datafusion::parquet::errors::Result<Vec<Bytes>>> {
-        const MAX_OVER_READ_SIZE: usize = 16384; // TODO: make it configurable
+        let max_over_read_size = conf::PARQUET_MAX_OVER_READ_SIZE
+          .value()
+          .unwrap_or(16384) as usize;
         let num_ranges = ranges.len();
         let (sorted_range_indices, sorted_ranges): (Vec<usize>, Vec<Range<usize>>) = ranges
             .into_iter()
@@ -378,7 +380,7 @@ impl AsyncFileReader for ParquetFileReaderRef {
             }
 
             let last_merged_range = merged_ranges.last_mut().unwrap();
-            if range.start <= last_merged_range.end + MAX_OVER_READ_SIZE {
+            if range.start <= last_merged_range.end + max_over_read_size {
                 last_merged_range.end = range.end.max(last_merged_range.end);
             } else {
                 merged_ranges.push(range);
@@ -439,8 +441,7 @@ impl AsyncFileReader for ParquetFileReaderRef {
     fn get_metadata(
         &mut self,
     ) -> BoxFuture<'_, datafusion::parquet::errors::Result<Arc<ParquetMetaData>>> {
-        const METADATA_CACHE_SIZE: usize = 5; // TODO: make it configurable
-
+        let metadata_cache_size = conf::PARQUET_METADATA_CACHE_SIZE.value().unwrap_or(5) as usize;
         type ParquetMetaDataSlot = tokio::sync::OnceCell<Arc<ParquetMetaData>>;
         type ParquetMetaDataCacheTable = Vec<(ObjectMeta, ParquetMetaDataSlot)>;
         static METADATA_CACHE: OnceCell<Mutex<ParquetMetaDataCacheTable>> = OnceCell::new();
@@ -459,7 +460,7 @@ impl AsyncFileReader for ParquetFileReaderRef {
             }
 
             // reserve a new cache slot
-            if metadata_cache.len() >= METADATA_CACHE_SIZE {
+            if metadata_cache.len() >= metadata_cache_size {
                 metadata_cache.remove(0); // remove eldest
             }
             let cache_slot = ParquetMetaDataSlot::default();

--- a/spark-extension/src/main/java/org/apache/spark/sql/blaze/BlazeConf.java
+++ b/spark-extension/src/main/java/org/apache/spark/sql/blaze/BlazeConf.java
@@ -72,6 +72,12 @@ public enum BlazeConf {
     // parquet enable bloom filter
     PARQUET_ENABLE_BLOOM_FILTER("spark.blaze.parquet.enable.bloomFilter", false),
 
+    // parquet max over read size
+    PARQUET_MAX_OVER_READ_SIZE("spark.blaze.parquet.maxOverReadSize", 16384),
+
+    // parquet metadata cache size
+    PARQUET_METADATA_CACHE_SIZE("spark.blaze.parquet.metadataCacheSize", 5),
+
     // spark io compression codec
     SPARK_IO_COMPRESSION_CODEC("spark.io.compression.codec", "lz4"),
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/kwai/blaze/issues/1104.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Make [MAX_OVER_READ_SIZE](https://github.com/kwai/blaze/blob/master/native-engine/datafusion-ext-plans/src/parquet_exec.rs#L365) and [METADATA_CACHE_SIZE](https://github.com/kwai/blaze/blob/master/native-engine/datafusion-ext-plans/src/parquet_exec.rs#L442) configurable

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR introduces two new Spark configurations:

- `spark.blaze.parquet.maxOverReadSize` (default: 16384)
- `spark.blaze.parquet.metadataCacheSize` (default: 5)

These parameters are now exposed via `BlazeConf` and are properly bridged to native Rust code using the `IntConf` trait.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes. Users can now configure:

```bash
--conf spark.blaze.parquet.maxOverReadSize=32768
--conf spark.blaze.parquet.metadataCacheSize=10
```
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
