### PR TITLE
[BLAZE-1107][FOLLOWUP] Reformat rust code

### DIFF
--- a/dev/reformat
+++ b/dev/reformat
@@ -42,4 +42,9 @@ do
   fi
 done
 
-
+# check or format the rust code
+if [[ "$CHECK" == "true" ]]; then
+  cargo fmt --check
+else
+  cargo fmt --all -q --
+fi


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
In #1107, we skip to build native for dev/reformat.

However, it skip the `cargo fmt --all -q --` as well.
 
 https://github.com/kwai/blaze/blob/8cd5fb74aa0a49cfd39e6c7f294b13d49a081b5e/build-native.sh#L61-L62 


In this PR, we add the `cargo fmt --all -q --` back to reformat rust code and also check the rust code format if `--check` option specified(in GA).

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No.