### PR TITLE
Make shuffle compression target buf size configurable

### DIFF
--- a/native-engine/blaze-jni-bridge/src/conf.rs
+++ b/native-engine/blaze-jni-bridge/src/conf.rs
@@ -47,6 +47,7 @@ define_conf!(StringConf, SPARK_IO_COMPRESSION_CODEC);
 define_conf!(IntConf, SPARK_IO_COMPRESSION_ZSTD_LEVEL);
 define_conf!(IntConf, TOKIO_WORKER_THREADS_PER_CPU);
 define_conf!(IntConf, SPARK_TASK_CPUS);
+define_conf!(IntConf, SHUFFLE_COMPRESSION_TARGET_BUF_SIZE);
 define_conf!(StringConf, SPILL_COMPRESSION_CODEC);
 define_conf!(BooleanConf, SMJ_FALLBACK_ENABLE);
 define_conf!(IntConf, SMJ_FALLBACK_ROWS_THRESHOLD);

--- a/native-engine/datafusion-ext-plans/src/common/ipc_compression.rs
+++ b/native-engine/datafusion-ext-plans/src/common/ipc_compression.rs
@@ -31,8 +31,6 @@ use datafusion_ext_commons::{
 };
 use once_cell::sync::OnceCell;
 
-pub const DEFAULT_SHUFFLE_COMPRESSION_TARGET_BUF_SIZE: usize = 4194304;
-
 pub struct IpcCompressionWriter<W: Write> {
     output: W,
     shared_buf: VecBuffer,
@@ -71,7 +69,12 @@ impl<W: Write> IpcCompressionWriter<W> {
         self.block_empty = false;
 
         let buf_len = self.shared_buf.inner().len();
-        if buf_len as f64 >= DEFAULT_SHUFFLE_COMPRESSION_TARGET_BUF_SIZE as f64 * 0.9 {
+        if buf_len as f64
+            >= conf::SHUFFLE_COMPRESSION_TARGET_BUF_SIZE
+                .value()
+                .unwrap_or(4194304) as f64 // default to 4MB
+                * 0.9
+        {
             self.finish_current_buf()?;
         }
         Ok(())

--- a/spark-extension/src/main/java/org/apache/spark/sql/blaze/BlazeConf.java
+++ b/spark-extension/src/main/java/org/apache/spark/sql/blaze/BlazeConf.java
@@ -93,6 +93,9 @@ public enum BlazeConf {
     // replace all sort-merge join to shuffled-hash join, only used for benchmarking
     FORCE_SHUFFLED_HASH_JOIN("spark.blaze.forceShuffledHashJoin", false),
 
+    // shuffle compression target buffer size, default is 4MB
+    SHUFFLE_COMPRESSION_TARGET_BUF_SIZE("spark.blaze.shuffle.compression.targetBufSize", 4194304),
+
     // spark spill compression codec
     SPILL_COMPRESSION_CODEC("spark.blaze.spill.compression.codec", "lz4"),
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
 Make SHUFFLE_COMPRESSION_TARGET_BUF_SIZE be configurable.
# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No.