### PR TITLE
[MINOR] Extract and unify plan conversion debug logs via BlazeLogUtils.scala

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
@@ -376,7 +376,9 @@ object BlazeConverters extends Logging {
 
   def convertProjectExec(exec: ProjectExec): SparkPlan = {
     val (projectList, child) = (exec.projectList, exec.child)
-    logDebugPlanConversion(exec, Seq("projectExprs" -> projectList.mkString("[", ", ", "]")))
+    if (log.isDebugEnabled) {
+      logDebugPlanConversion(exec, Seq("projectExprs" -> projectList.mkString("[", ", ", "]")))
+    }
     Shims.get.createNativeProjectExec(projectList, addRenameColumnsExec(convertToNative(child)))
   }
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
@@ -369,7 +369,7 @@ object BlazeConverters extends Logging {
       case p =>
         throw new NotImplementedError(
           s"Cannot convert FileSourceScanExec tableIdentifier: ${tableIdentifier.getOrElse(
-              "unknown")}, class: ${p.getClass.getName}")
+            "unknown")}, class: ${p.getClass.getName}")
     }
   }
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/util/BlazeLogUtils.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/util/BlazeLogUtils.scala
@@ -21,11 +21,11 @@ import org.apache.spark.sql.execution.SparkPlan
 
 object BlazeLogUtils extends Logging {
 
-  def logPlanConversion(plan: SparkPlan, fields: (String, Any)*): Unit = {
+  def logPlanConversion(plan: SparkPlan, fields: => Seq[(String, Any)] = Nil): Unit = {
     if (log.isDebugEnabled) {
       val header = s"Converting ${plan.nodeName}: ${Shims.get.simpleStringWithNodeId(plan)}"
       val body = fields.map { case (k, v) => s"  $k: $v" }.mkString("\n")
-      logDebug(s"$header\n$body")
+      logDebug(s"$header\n$body".trim)
     }
   }
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/util/BlazeLogUtils.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/util/BlazeLogUtils.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 The Blaze Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.blaze.util
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.blaze.Shims
+import org.apache.spark.sql.execution.SparkPlan
+
+object BlazeLogUtils extends Logging {
+
+  def logPlanConversion(plan: SparkPlan, fields: (String, Any)*): Unit = {
+    if (log.isDebugEnabled) {
+      val header = s"Converting ${plan.nodeName}: ${Shims.get.simpleStringWithNodeId(plan)}"
+      val body = fields.map { case (k, v) => s"  $k: $v" }.mkString("\n")
+      logDebug(s"$header\n$body")
+    }
+  }
+}

--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/util/BlazeLogUtils.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/util/BlazeLogUtils.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.execution.SparkPlan
 
 object BlazeLogUtils extends Logging {
 
-  def logPlanConversion(plan: SparkPlan, fields: => Seq[(String, Any)] = Nil): Unit = {
+  def logDebugPlanConversion(plan: SparkPlan, fields: => Seq[(String, Any)] = Nil): Unit = {
     if (log.isDebugEnabled) {
       val header = s"Converting ${plan.nodeName}: ${Shims.get.simpleStringWithNodeId(plan)}"
       val body = fields.map { case (k, v) => s"  $k: $v" }.mkString("\n")

--- a/spark-extension/src/main/scala/org/apache/spark/sql/hive/blaze/BlazeHiveConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/hive/blaze/BlazeHiveConverters.scala
@@ -17,7 +17,7 @@ package org.apache.spark.sql.hive.blaze
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.blaze.BlazeConverters.addRenameColumnsExec
-import org.apache.spark.sql.blaze.util.BlazeLogUtils.logPlanConversion
+import org.apache.spark.sql.blaze.util.BlazeLogUtils.logDebugPlanConversion
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.hive.execution.HiveTableScanExec
 import org.apache.spark.sql.hive.execution.blaze.plan.NativePaimonTableScanExec
@@ -45,7 +45,7 @@ object BlazeHiveConverters extends Logging {
       hiveExec.output,
       hiveExec.requestedAttributes,
       hiveExec.partitionPruningPred)
-    logPlanConversion(
+    logDebugPlanConversion(
       exec,
       Seq(
         "relation" -> relation.getClass,

--- a/spark-extension/src/main/scala/org/apache/spark/sql/hive/blaze/BlazeHiveConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/hive/blaze/BlazeHiveConverters.scala
@@ -47,11 +47,12 @@ object BlazeHiveConverters extends Logging {
       hiveExec.partitionPruningPred)
     logPlanConversion(
       exec,
-      "relation" -> relation.getClass,
-      "relation.location" -> relation.tableMeta.location,
-      "output" -> output,
-      "requestedAttributes" -> requestedAttributes,
-      "partitionPruningPred" -> partitionPruningPred)
+      Seq(
+        "relation" -> relation.getClass,
+        "relation.location" -> relation.tableMeta.location,
+        "output" -> output,
+        "requestedAttributes" -> requestedAttributes,
+        "partitionPruningPred" -> partitionPruningPred))
 
     addRenameColumnsExec(NativePaimonTableScanExec(hiveExec))
   }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/hive/blaze/BlazeHiveConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/hive/blaze/BlazeHiveConverters.scala
@@ -17,7 +17,7 @@ package org.apache.spark.sql.hive.blaze
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.blaze.BlazeConverters.addRenameColumnsExec
-import org.apache.spark.sql.blaze.Shims
+import org.apache.spark.sql.blaze.util.BlazeLogUtils.logPlanConversion
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.hive.execution.HiveTableScanExec
 import org.apache.spark.sql.hive.execution.blaze.plan.NativePaimonTableScanExec
@@ -45,12 +45,13 @@ object BlazeHiveConverters extends Logging {
       hiveExec.output,
       hiveExec.requestedAttributes,
       hiveExec.partitionPruningPred)
-    logDebug(s"Converting HiveTableScanExec: ${Shims.get.simpleStringWithNodeId(exec)}")
-    logDebug(s"  relation: ${relation.getClass}")
-    logDebug(s"  relation.location: ${relation.tableMeta.location}")
-    logDebug(s"  output: $output")
-    logDebug(s"  requestedAttributes: $requestedAttributes")
-    logDebug(s"  partitionPruningPred: $partitionPruningPred")
+    logPlanConversion(
+      exec,
+      "relation" -> relation.getClass,
+      "relation.location" -> relation.tableMeta.location,
+      "output" -> output,
+      "requestedAttributes" -> requestedAttributes,
+      "partitionPruningPred" -> partitionPruningPred)
 
     addRenameColumnsExec(NativePaimonTableScanExec(hiveExec))
   }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This PR introduces a shared logging utility `BlazeLogUtils.logDbugPlanConversion` under blaze.util to unify plan conversion debug messages across `BlazeConverters` and `BlazeHiveConverters`, improving log structure, readability, and maintainability.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
* Introduce `BlazeLogUtils.scala` class containing the `logDebugPlanConversion` method to extract and unify plan conversion debug logs.

* Modify logDebug in both `BlazeConverters.scala` and `BlazeHiveConverters.scala` to use the new unified logging utility.


# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
