### PR TITLE
Remove unused code and skip scalafix with `// scalafix:off`

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
@@ -136,10 +136,11 @@ object BlazeConverters extends Logging {
   def enableScanOrc: Boolean =
     getBooleanConf("spark.blaze.enable.scan.orc", defaultValue = true)
 
+  // scalafix:off
+  // necessary imports for cross spark versions build
   import org.apache.spark.sql.catalyst.plans._
   import org.apache.spark.sql.catalyst.optimizer._
-  var _UnusedQueryPlan: QueryPlan[_] = _
-  var _UnusedOptimizer: Optimizer = _
+  // scalafix:on
 
   def convertSparkPlanRecursively(exec: SparkPlan): SparkPlan = {
     // convert


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Followup #1119 
I checked the `dev/reformat` script, seems it uses both `spotless` and `scalafix` to reformat the code.

I tried to add `// scalafix:off` to disable the scalafix for code snip, and seems it works.

I think this PR is an example to instruct how to skip code snip scalafix in the project.
# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
