### PR TITLE
[BLAZE-1127] Support to build blaze on scala-2.13

### DIFF
--- a/.github/workflows/build-ce7-releases.yml
+++ b/.github/workflows/build-ce7-releases.yml
@@ -12,8 +12,20 @@ jobs:
     strategy:
       matrix:
         sparkver: [spark-3.0, spark-3.1, spark-3.2, spark-3.3, spark-3.4, spark-3.5]
+        scalaver: [ 2.12, 2.13 ]
         blazever: [5.0.0]
-
+        exclude:
+          # Only build scala-2.13 for spark-3.5
+          - sparkver: spark-3.0
+            scalaver: '2.13'
+          - sparkver: spark-3.1
+            scalaver: '2.13'
+          - sparkver: spark-3.2
+            scalaver: '2.13'
+          - sparkver: spark-3.3
+            scalaver: '2.13'
+          - sparkver: spark-3.4
+            scalaver: '2.13'
     steps:
       - uses: actions/checkout@v4
       - uses: s4u/setup-maven-action@main
@@ -22,12 +34,12 @@ jobs:
       - uses: prompt/actions-commit-hash@v3
         id: commit
 
-      - name: Cache blaze-engine-${{ matrix.sparkver }}
+      - name: Cache blaze-engine-${{ matrix.sparkver }}_${{ matrix.scalaver }}
         id: cache
         uses: actions/cache@v3
         with:
-          path: target-docker/blaze-engine-${{matrix.sparkver}}-release-${{ matrix.blazever }}-SNAPSHOT.jar
-          key: blaze-engine-${{matrix.sparkver}}-release-${{ matrix.blazever }}-SNAPSHOT.jar
+          path: target-docker/blaze-engine-${{matrix.sparkver}}_${{matrix.scalaver}}-release-${{ matrix.blazever }}-SNAPSHOT.jar
+          key: blaze-engine-${{matrix.sparkver}}_${{matrix.scalaver}}-release-${{ matrix.blazever }}-SNAPSHOT.jar
 
       - uses: ScribeMD/rootless-docker@0.2.2
         if: steps.cache.outputs.cache-hit != 'true'
@@ -37,14 +49,14 @@ jobs:
         with:
           key: docker-centos7-${{ hashFiles('dev/docker-build/centos7/Dockerfile') }}
 
-      - name: Build blaze-engine-${{ matrix.sparkver }}
+      - name: Build blaze-engine-${{ matrix.sparkver }}_${{ matrix.scalaver }}
         run: |
           sed -i 's/docker-compose -f/docker compose -f/g' ./release-docker.sh
-          SHIM=${{ matrix.sparkver }} MODE=release ./release-docker.sh
+          SHIM=${{ matrix.sparkver }} MODE=release SCALA_VERSION=${{ matrix.scalaver }} ./release-docker.sh
 
-      - name: Upload blaze-engine-${{ matrix.sparkver }}
+      - name: Upload blaze-engine-${{ matrix.sparkver }}_${{ matrix.scalaver }}
         uses: actions/upload-artifact@v4
         with:
-          name: blaze-engine-${{matrix.sparkver}}-release-${{ matrix.blazever }}-SNAPSHOT-ce7-${{ steps.commit.outputs.short }}.jar
-          path: target-docker/blaze-engine-${{matrix.sparkver}}-release-${{ matrix.blazever }}-SNAPSHOT.jar
+          name: blaze-engine-${{matrix.sparkver}}_${{matrix.scalaver}}-release-${{ matrix.blazever }}-SNAPSHOT-ce7-${{ steps.commit.outputs.short }}.jar
+          path: target-docker/blaze-engine-${{matrix.sparkver}}_${{matrix.scalaver}}-release-${{ matrix.blazever }}-SNAPSHOT.jar
           overwrite: true

--- a/.github/workflows/build-ce7-releases.yml
+++ b/.github/workflows/build-ce7-releases.yml
@@ -1,7 +1,6 @@
 name: Build Centos7 Releases
 
 on:
-  pull_request:
   workflow_dispatch:
   push:
     branches: ["master"]
@@ -16,7 +15,7 @@ jobs:
         scalaver: [ 2.12, 2.13 ]
         blazever: [5.0.0]
         exclude:
-          # Only build scala-2.13 for spark-3.5
+          # Only build on scala-2.13 for spark-3.5
           - sparkver: spark-3.0
             scalaver: '2.13'
           - sparkver: spark-3.1
@@ -27,6 +26,7 @@ jobs:
             scalaver: '2.13'
           - sparkver: spark-3.4
             scalaver: '2.13'
+
     steps:
       - uses: actions/checkout@v4
       - uses: s4u/setup-maven-action@main

--- a/.github/workflows/build-ce7-releases.yml
+++ b/.github/workflows/build-ce7-releases.yml
@@ -1,6 +1,7 @@
 name: Build Centos7 Releases
 
 on:
+  pull_request:
   workflow_dispatch:
   push:
     branches: ["master"]

--- a/.github/workflows/tpcds-reusable.yml
+++ b/.github/workflows/tpcds-reusable.yml
@@ -32,8 +32,7 @@ jobs:
       - uses: actions/checkout@v4
         if: steps.cache-tpcds-validator.outputs.cache-hit != 'true'
         with:
-          # TODO: wait https://github.com/blaze-init/tpcds-validator/pull/1 merged
-          repository: turboFei/tpcds-validator
+          repository: blaze-init/tpcds-validator
 
       - uses: actions/setup-java@v4
         if: steps.cache-tpcds-validator.outputs.cache-hit != 'true'

--- a/.github/workflows/tpcds-reusable.yml
+++ b/.github/workflows/tpcds-reusable.yml
@@ -26,13 +26,14 @@ jobs:
       - uses: actions/cache@v4
         id: cache-tpcds-validator
         with:
-          key: tpcds-validator
-          path: target/tpcds-validator_2.12-0.1.0-SNAPSHOT-with-dependencies.jar
+          key: tpcds-validator_${{ inputs.scalaver }}
+          path: target/tpcds-validator_${{ inputs.scalaver }}-0.1.0-SNAPSHOT-with-dependencies.jar
 
       - uses: actions/checkout@v4
         if: steps.cache-tpcds-validator.outputs.cache-hit != 'true'
         with:
-          repository: blaze-init/tpcds-validator
+          # TODO: wait https://github.com/blaze-init/tpcds-validator/pull/1 merged
+          repository: turboFei/tpcds-validator
 
       - uses: actions/setup-java@v4
         if: steps.cache-tpcds-validator.outputs.cache-hit != 'true'
@@ -43,13 +44,13 @@ jobs:
 
       - name: Build
         if: steps.cache-tpcds-validator.outputs.cache-hit != 'true'
-        run: mvn package -DskipTests
+        run: ./build/mvn package -DskipTests -Pscala-${{ inputs.scalaver }}
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: tpcds-validator-${{ inputs.sparkver }}_${{ inputs.scalaver }}-jdk-${{ inputs.javaver }}
-          path: target/tpcds-validator_2.12-0.1.0-SNAPSHOT-with-dependencies.jar
+          path: target/tpcds-validator_${{ inputs.scalaver }}-0.1.0-SNAPSHOT-with-dependencies.jar
           overwrite: true
 
   build-blaze-jar:

--- a/.github/workflows/tpcds-reusable.yml
+++ b/.github/workflows/tpcds-reusable.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: '8'
+      scalaver:
+        required: false
+        type: string
+        default: '2.12'
 
 jobs:
   build-validator:
@@ -44,7 +48,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: tpcds-validator-${{ inputs.sparkver }}-jdk-${{ inputs.javaver }}
+          name: tpcds-validator-${{ inputs.sparkver }}_${{ inputs.scalaver }}-jdk-${{ inputs.javaver }}
           path: target/tpcds-validator_2.12-0.1.0-SNAPSHOT-with-dependencies.jar
           overwrite: true
 
@@ -78,14 +82,14 @@ jobs:
       - name: Cargo test
         run: cargo +nightly test --workspace --all-features
 
-      - name: Build ${{ inputs.sparkver }} jdk-${{ inputs.javaver }}
-        run: mvn package -Ppre -P${{ inputs.sparkver }} -Pjdk-${{ inputs.javaver }}
+      - name: Build ${{ inputs.sparkver }}_${{ inputs.scalaver }} jdk-${{ inputs.javaver }}
+        run: mvn package -Ppre -P${{ inputs.sparkver }} -Pscala-${{ inputs.scalaver }} -Pjdk-${{ inputs.javaver }}
 
-      - name: Upload ${{ inputs.sparkver }} jdk-${{ inputs.javaver }}
+      - name: Upload ${{ inputs.sparkver }}_${{ inputs.scalaver }} jdk-${{ inputs.javaver }}
         uses: actions/upload-artifact@v4
         with:
-          name: blaze-engine-${{ inputs.sparkver }}-jdk-${{ inputs.javaver }}
-          path: target/blaze-engine-${{ inputs.sparkver }}-pre-*-SNAPSHOT.jar
+          name: blaze-engine-${{ inputs.sparkver }}_${{ inputs.scalaver }}-jdk-${{ inputs.javaver }}
+          path: target/blaze-engine-${{ inputs.sparkver }}_${{ inputs.scalaver }}-pre-*-SNAPSHOT.jar
           overwrite: true
 
   run-tpcds-test:
@@ -113,24 +117,24 @@ jobs:
       - uses: actions/cache@v4
         id: cache-spark-bin
         with:
-          path: spark-bin-${{ inputs.sparkver }}
-          key: spark-bin-${{ inputs.sparkver }}
+          path: spark-bin-${{ inputs.sparkver }}_${{ inputs.scalaver }}
+          key: spark-bin-${{ inputs.sparkver }}_${{ inputs.scalaver }}
 
       - name: Setup ${{ inputs.sparkver }}
         id: setup-spark-bin
         if: steps.cache-spark-bin.outputs.cache-hit != 'true'
         run: |
           wget -c ${{ inputs.sparkurl }}
-          mkdir -p spark-bin-${{ inputs.sparkver }}
-          cd spark-bin-${{ inputs.sparkver }} && tar -xf ../spark-*.tgz --strip-component=1
+          mkdir -p spark-bin-${{ inputs.sparkver }}_${{ inputs.scalaver }}
+          cd spark-bin-${{ inputs.sparkver }}_${{ inputs.scalaver }} && tar -xf ../spark-*.tgz --strip-component=1
 
       - uses: actions/download-artifact@v4
         with:
-          name: blaze-engine-${{ inputs.sparkver }}-jdk-${{ inputs.javaver }}
+          name: blaze-engine-${{ inputs.sparkver }}_${{ inputs.scalaver }}-jdk-${{ inputs.javaver }}
 
       - uses: actions/download-artifact@v4
         with:
-          name: tpcds-validator-${{ inputs.sparkver }}-jdk-${{ inputs.javaver }}
+          name: tpcds-validator-${{ inputs.sparkver }}_${{ inputs.scalaver }}-jdk-${{ inputs.javaver }}
 
       - name: Checkout TPC-DS Data
         uses: actions/checkout@v4
@@ -141,7 +145,7 @@ jobs:
       - name: Install Blaze JAR
         run: |
           ls -la
-          cp blaze-engine-*${{ inputs.sparkver }}*.jar spark-bin-${{ inputs.sparkver }}/jars/
+          cp blaze-engine-*${{ inputs.sparkver }}_${{ inputs.scalaver }}*.jar spark-bin-${{ inputs.sparkver }}_${{ inputs.scalaver }}/jars/
 
       - uses: actions/setup-java@v4
         with:
@@ -154,6 +158,6 @@ jobs:
           ls -la
           export RUST_LOG=ERROR
           export RUST_BACKTRACE=1
-          SPARK_HOME=spark-bin-${{ inputs.sparkver }} dev/run-tpcds-test \
+          SPARK_HOME=spark-bin-${{ inputs.sparkver }}_${{ inputs.scalaver }} dev/run-tpcds-test \
             --data-location dev/tpcds_1g \
             --query-filter ${{ matrix.query }}

--- a/.github/workflows/tpcds-reusable.yml
+++ b/.github/workflows/tpcds-reusable.yml
@@ -159,6 +159,7 @@ jobs:
           ls -la
           export RUST_LOG=ERROR
           export RUST_BACKTRACE=1
+          export SCALA_VERSION=${{ inputs.scalaver }}
           SPARK_HOME=spark-bin-${{ inputs.sparkver }}_${{ inputs.scalaver }} dev/run-tpcds-test \
             --data-location dev/tpcds_1g \
             --query-filter ${{ matrix.query }}

--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -60,10 +60,20 @@ jobs:
       sparkurl: https://archive.apache.org/dist/spark/spark-3.5.5/spark-3.5.5-bin-hadoop3.tgz
       javaver: '11'
 
-  test-spark-35-jdk17:
-    name: Test spark-3.5 JDK17
+  test-spark-35-jdk17-scala-2-12:
+    name: Test spark-3.5 JDK17 Scala-2.12
     uses: ./.github/workflows/tpcds-reusable.yml
     with:
       sparkver: spark-3.5
       sparkurl: https://archive.apache.org/dist/spark/spark-3.5.5/spark-3.5.5-bin-hadoop3.tgz
       javaver: '17'
+      scalaver: '2.12'
+
+  test-spark-35-jdk17-scala-2-13:
+    name: Test spark-3.5 JDK17 Scala-2.13
+    uses: ./.github/workflows/tpcds-reusable.yml
+    with:
+      sparkver: spark-3.5
+      sparkurl: https://archive.apache.org/dist/spark/spark-3.5.5/spark-3.5.5-bin-hadoop3-scala2.13.tgz
+      javaver: '17'
+      scalaver: '2.13'

--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -60,15 +60,6 @@ jobs:
       sparkurl: https://archive.apache.org/dist/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz
       javaver: '11'
 
-  test-spark-35-jdk17-scala-2-12:
-    name: Test spark-3.5 JDK17 Scala-2.12
-    uses: ./.github/workflows/tpcds-reusable.yml
-    with:
-      sparkver: spark-3.5
-      sparkurl: https://archive.apache.org/dist/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz
-      javaver: '17'
-      scalaver: '2.12'
-
   test-spark-35-jdk17-scala-2-13:
     name: Test spark-3.5 JDK17 Scala-2.13
     uses: ./.github/workflows/tpcds-reusable.yml

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Blaze.
 SHIM=spark-3.3 # or spark-3.0/spark-3.1/spark-3.2/spark-3.3/spark-3.4/spark-3.5
 MODE=release # or pre
 JAVA_VERSION=8 # or 11/17
-./build/mvn clean package -P"${SHIM}" -P"${MODE} -P"jdk-${JAVA_VERSION}"
+SCALA_VERSION=2.12 # or 2.13
+./build/mvn clean package -P"${SHIM}" -P"${MODE} -P"jdk-${JAVA_VERSION}" -P"scala-${SCALA_VERSION}"
 ```
 
 Skip build native (native lib is already built, and you can check the native lib in `native-engine/_build/${MODE}`).
@@ -101,7 +102,8 @@ Skip build native (native lib is already built, and you can check the native lib
 SHIM=spark-3.3 # or spark-3.0/spark-3.1/spark-3.2/spark-3.3/spark-3.4/spark-3.5
 MODE=release # or pre
 JAVA_VERSION=8 # or 11/17
-./build/mvn clean package -P"${SHIM}" -P"${MODE}" -P"jdk-${JAVA_VERSION}" -DskipBuildNative
+SCALA_VERSION=2.12 # or 2.13
+./build/mvn clean package -P"${SHIM}" -P"${MODE}" -P"jdk-${JAVA_VERSION}" -P"scala-${SCALA_VERSION}" -DskipBuildNative
 ```
 
 After the build is finished, a fat Jar package that contains all the dependencies will be generated in the `target`
@@ -111,7 +113,7 @@ directory.
 
 You can use the following command to build a centos-7 compatible release:
 ```shell
-SHIM=spark-3.3 MODE=release JAVA_VERSION=8 ./release-docker.sh
+SHIM=spark-3.3 MODE=release JAVA_VERSION=8 SCALA_VERSION=2.12 ./release-docker.sh
 ```
 
 ## Run Spark Job with Blaze Accelerator

--- a/dev/docker-build/docker-compose.yml
+++ b/dev/docker-build/docker-compose.yml
@@ -19,4 +19,5 @@ services:
       SHIM: "${SHIM}"
       MODE: "${MODE}"
       JAVA_VERSION: "${JAVA_VERSION}"
-    command: "bash -c 'source ~/.bashrc && cd /blaze && mvn -T8 package -P${SHIM} -P${MODE} -Pjdk-${JAVA_VERSION}'"
+      SCALA_VERSION: "${SCALA_VERSION}"
+    command: "bash -c 'source ~/.bashrc && cd /blaze && mvn -T8 package -P${SHIM} -P${MODE} -Pjdk-${JAVA_VERSION} -Pscala-${SCALA_VERSION}'"

--- a/dev/mvn-build-helper/assembly/pom.xml
+++ b/dev/mvn-build-helper/assembly/pom.xml
@@ -4,7 +4,7 @@
 
   <parent>
     <groupId>org.blaze</groupId>
-    <artifactId>blaze-engine</artifactId>
+    <artifactId>blaze-engine_${scalaVersion}</artifactId>
     <version>${revision}</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
@@ -19,12 +19,12 @@
   <dependencies>
     <dependency>
       <groupId>org.blaze</groupId>
-      <artifactId>spark-extension</artifactId>
+      <artifactId>spark-extension_${scalaVersion}</artifactId>
       <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.blaze</groupId>
-      <artifactId>${shimPkg}</artifactId>
+      <artifactId>${shimPkg}_${scalaVersion}</artifactId>
       <version>${revision}</version>
     </dependency>
   </dependencies>
@@ -110,7 +110,7 @@
               <archive>
                 <addMavenDescriptor>false</addMavenDescriptor>
               </archive>
-              <outputFile>../../../target/blaze-engine-${shimName}-${releaseMode}-${revision}.jar</outputFile>
+              <outputFile>../../../target/blaze-engine-${shimName}_${scalaVersion}-${releaseMode}-${revision}.jar</outputFile>
             </configuration>
           </execution>
         </executions>

--- a/dev/mvn-build-helper/proto/pom.xml
+++ b/dev/mvn-build-helper/proto/pom.xml
@@ -4,7 +4,7 @@
 
   <parent>
     <groupId>org.blaze</groupId>
-    <artifactId>blaze-engine</artifactId>
+    <artifactId>blaze-engine_${scalaVersion}</artifactId>
     <version>${revision}</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>

--- a/dev/reformat
+++ b/dev/reformat
@@ -30,15 +30,16 @@ while (( "$#" )); do
 done
 
 sparkver=(spark-3.0 spark-3.1 spark-3.2 spark-3.3 spark-3.4 spark-3.5)
+SCALA_PROFILE=scala-2.12
 
 MODE=pre
 for ver in ${sparkver[@]}
 do
   SHIM=$ver
   if [[ "$CHECK" == "true" ]]; then
-    mvn spotless:check compile test-compile scalafix:scalafix -Dscalafix.mode=CHECK -Dscalafix.skipTest=true -DskipBuildNative -P"${SHIM}" -P"${MODE}"
+    mvn spotless:check compile test-compile scalafix:scalafix -Dscalafix.mode=CHECK -Dscalafix.skipTest=true -DskipBuildNative -P"${SHIM}" -P"${MODE}" -P"${SCALA_PROFILE}"
   else
-    mvn spotless:apply compile test-compile scalafix:scalafix -DskipBuildNative -P"${SHIM}" -P"${MODE}"
+    mvn spotless:apply compile test-compile scalafix:scalafix -DskipBuildNative -P"${SHIM}" -P"${MODE}" -P"${SCALA_PROFILE}"
   fi
 done
 

--- a/dev/reformat
+++ b/dev/reformat
@@ -42,5 +42,3 @@ do
     mvn spotless:apply compile test-compile scalafix:scalafix -DskipBuildNative -P"${SHIM}" -P"${MODE}" -P"${SCALA_PROFILE}"
   fi
 done
-
-

--- a/dev/run-tpcds-test
+++ b/dev/run-tpcds-test
@@ -36,7 +36,7 @@ parse_args_for_spark_submit "$@"
 
 # Resolve a jar location for the TPCDS data generator
 find_resource() {
-  local jar_file="tpcds-validator_2.12-0.1.0-SNAPSHOT-with-dependencies.jar"
+  local jar_file="tpcds-validator_${SCALA_VERSION:-2.12}-0.1.0-SNAPSHOT-with-dependencies.jar"
   local built_jar="$_DIR/../${jar_file}"
   if [[ -e "$built_jar" ]]; then
     RESOURCE=$built_jar

--- a/hadoop-shim/pom.xml
+++ b/hadoop-shim/pom.xml
@@ -4,12 +4,12 @@
 
   <parent>
     <groupId>org.blaze</groupId>
-    <artifactId>blaze-engine</artifactId>
+    <artifactId>blaze-engine_${scalaVersion}</artifactId>
     <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>org.blaze</groupId>
-  <artifactId>hadoop-shim</artifactId>
+  <artifactId>hadoop-shim_${scalaVersion}</artifactId>
   <packaging>jar</packaging>
 
   <dependencies>
@@ -20,7 +20,7 @@
     </dependency>
     <dependency>
       <groupId>org.scala-lang.modules</groupId>
-      <artifactId>scala-java8-compat_2.12</artifactId>
+      <artifactId>scala-java8-compat_${scalaVersion}</artifactId>
       <version>1.0.2</version>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.blaze</groupId>
-  <artifactId>blaze-engine</artifactId>
+  <artifactId>blaze-engine_${scalaVersion}</artifactId>
   <version>${revision}</version>
   <packaging>pom</packaging>
 
@@ -24,9 +24,13 @@
     <celebornVersion>0.6.0</celebornVersion>
 
     <javaVersion>8</javaVersion>
+    <scalaVersion>2.12</scalaVersion>
+    <scalaLongVersion>2.12.17</scalaLongVersion>
     <maven.version>3.8.1</maven.version>
     <maven.plugin.scala.version>4.9.2</maven.plugin.scala.version>
     <maven.plugin.shade.version>3.5.2</maven.plugin.shade.version>
+    <scalamacros.paradise.version>2.1.1</scalamacros.paradise.version>
+    <semanticdb.version>4.8.1</semanticdb.version>
   </properties>
 
   <dependencyManagement>
@@ -159,12 +163,12 @@
             <compilerPlugin>
               <groupId>org.scalameta</groupId>
               <artifactId>semanticdb-scalac_${scalaLongVersion}</artifactId>
-              <version>4.8.1</version>
+              <version>${semanticdb.version}</version>
             </compilerPlugin>
             <compilerPlugin>
               <groupId>org.scalamacros</groupId>
               <artifactId>paradise_${scalaLongVersion}</artifactId>
-              <version>2.1.1</version>
+              <version>${scalamacros.paradise.version}</version>
             </compilerPlugin>
           </compilerPlugins>
         </configuration>
@@ -328,8 +332,6 @@
       <properties>
         <shimName>spark-3.0</shimName>
         <shimPkg>spark-extension-shims-spark3</shimPkg>
-        <scalaVersion>2.12</scalaVersion>
-        <scalaLongVersion>2.12.17</scalaLongVersion>
         <scalaTestVersion>3.0.8</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.0.3</sparkVersion>
@@ -341,8 +343,6 @@
       <properties>
         <shimName>spark-3.1</shimName>
         <shimPkg>spark-extension-shims-spark3</shimPkg>
-        <scalaVersion>2.12</scalaVersion>
-        <scalaLongVersion>2.12.15</scalaLongVersion>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.1.3</sparkVersion>
@@ -354,8 +354,6 @@
       <properties>
         <shimName>spark-3.2</shimName>
         <shimPkg>spark-extension-shims-spark3</shimPkg>
-        <scalaVersion>2.12</scalaVersion>
-        <scalaLongVersion>2.12.15</scalaLongVersion>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.2.4</sparkVersion>
@@ -367,8 +365,6 @@
       <properties>
         <shimName>spark-3.3</shimName>
         <shimPkg>spark-extension-shims-spark3</shimPkg>
-        <scalaVersion>2.12</scalaVersion>
-        <scalaLongVersion>2.12.15</scalaLongVersion>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.3.4</sparkVersion>
@@ -380,8 +376,6 @@
       <properties>
         <shimName>spark-3.4</shimName>
         <shimPkg>spark-extension-shims-spark3</shimPkg>
-        <scalaVersion>2.12</scalaVersion>
-        <scalaLongVersion>2.12.15</scalaLongVersion>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.4.4</sparkVersion>
@@ -393,8 +387,6 @@
       <properties>
         <shimName>spark-3.5</shimName>
         <shimPkg>spark-extension-shims-spark3</shimPkg>
-        <scalaVersion>2.12</scalaVersion>
-        <scalaLongVersion>2.12.15</scalaLongVersion>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.5.5</sparkVersion>
@@ -429,6 +421,44 @@
       <properties>
         <javaVersion>17</javaVersion>
       </properties>
+    </profile>
+
+    <profile>
+      <id>scala-2.13</id>
+      <activation>
+        <property>
+          <name>scalaVersion</name>
+          <value>2.13</value>
+        </property>
+      </activation>
+      <properties>
+        <scalaVersion>2.13</scalaVersion>
+        <scalaLongVersion>2.13.8</scalaLongVersion>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <configuration>
+              <args>
+                <arg>-Ywarn-unused</arg>
+                <!-- https://github.com/scalamacros/paradise is no longer actively developed. -->
+                <!-- In Scala 2.13, the plugin's functionality has been included in the compiler -->
+                <!-- directly under the -Ymacro-annotations flag.  -->
+                <arg>-Ymacro-annotations</arg>
+              </args>
+              <compilerPlugins>
+                <compilerPlugin>
+                  <groupId>org.scalameta</groupId>
+                  <artifactId>semanticdb-scalac_${scalaLongVersion}</artifactId>
+                  <version>${semanticdb.version}</version>
+                </compilerPlugin>
+              </compilerPlugins>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -159,18 +159,6 @@
           <jvmArgs>
             <jvmArg>-Dblaze.shim=${shimName}</jvmArg>
           </jvmArgs>
-          <compilerPlugins>
-            <compilerPlugin>
-              <groupId>org.scalameta</groupId>
-              <artifactId>semanticdb-scalac_${scalaLongVersion}</artifactId>
-              <version>${semanticdb.version}</version>
-            </compilerPlugin>
-            <compilerPlugin>
-              <groupId>org.scalamacros</groupId>
-              <artifactId>paradise_${scalaLongVersion}</artifactId>
-              <version>${scalamacros.paradise.version}</version>
-            </compilerPlugin>
-          </compilerPlugins>
         </configuration>
         <dependencies>
           <dependency>
@@ -421,6 +409,38 @@
       <properties>
         <javaVersion>17</javaVersion>
       </properties>
+    </profile>
+
+    <profile>
+      <id>scala-2.12</id>
+      <activation>
+        <property>
+          <name>scalaVersion</name>
+          <value>2.12</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <configuration>
+              <compilerPlugins>
+                <compilerPlugin>
+                  <groupId>org.scalameta</groupId>
+                  <artifactId>semanticdb-scalac_${scalaLongVersion}</artifactId>
+                  <version>${semanticdb.version}</version>
+                </compilerPlugin>
+                <compilerPlugin>
+                  <groupId>org.scalamacros</groupId>
+                  <artifactId>paradise_${scalaLongVersion}</artifactId>
+                  <version>${scalamacros.paradise.version}</version>
+                </compilerPlugin>
+              </compilerPlugins>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>

--- a/release-docker.sh
+++ b/release-docker.sh
@@ -3,5 +3,6 @@
 export SHIM="${SHIM:-spark-3.0}"
 export MODE="${MODE:-release}"
 export JAVA_VERSION="${JAVA_VERSION:-8}"
+export SCALA_VERSION="${SCALA_VERSION:-2.12}"
 
 docker-compose -f dev/docker-build/docker-compose.yml up

--- a/spark-extension-shims-spark3/pom.xml
+++ b/spark-extension-shims-spark3/pom.xml
@@ -4,18 +4,18 @@
 
   <parent>
     <groupId>org.blaze</groupId>
-    <artifactId>blaze-engine</artifactId>
+    <artifactId>blaze-engine_${scalaVersion}</artifactId>
     <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>org.blaze</groupId>
-  <artifactId>spark-extension-shims-spark3</artifactId>
+  <artifactId>spark-extension-shims-spark3_${scalaVersion}</artifactId>
   <packaging>jar</packaging>
 
   <dependencies>
     <dependency>
       <groupId>org.blaze</groupId>
-      <artifactId>spark-extension</artifactId>
+      <artifactId>spark-extension_${scalaVersion}</artifactId>
       <version>${revision}</version>
     </dependency>
     <dependency>
@@ -25,7 +25,7 @@
     </dependency>
     <dependency>
       <groupId>org.scala-lang.modules</groupId>
-      <artifactId>scala-java8-compat_2.12</artifactId>
+      <artifactId>scala-java8-compat_${scalaVersion}</artifactId>
       <version>1.0.2</version>
       <exclusions>
         <exclusion>

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeShuffleManager.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/BlazeShuffleManager.scala
@@ -89,7 +89,7 @@ class BlazeShuffleManager(conf: SparkConf) extends ShuffleManager with Logging {
 
       new BlazeBlockStoreShuffleReader(
         handle.asInstanceOf[BaseShuffleHandle[K, _, C]],
-        blocksByAddress,
+        blocksByAddress.map(tup => (tup._1, tup._2.toSeq)),
         context,
         metrics,
         SparkEnv.get.blockManager,

--- a/spark-extension/pom.xml
+++ b/spark-extension/pom.xml
@@ -4,18 +4,18 @@
 
   <parent>
     <groupId>org.blaze</groupId>
-    <artifactId>blaze-engine</artifactId>
+    <artifactId>blaze-engine_${scalaVersion}</artifactId>
     <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>org.blaze</groupId>
-  <artifactId>spark-extension</artifactId>
+  <artifactId>spark-extension_${scalaVersion}</artifactId>
   <packaging>jar</packaging>
 
   <dependencies>
     <dependency>
       <groupId>org.blaze</groupId>
-      <artifactId>spark-version-annotation-macros</artifactId>
+      <artifactId>spark-version-annotation-macros_${scalaVersion}</artifactId>
       <version>${revision}</version>
       <scope>compile</scope>
     </dependency>
@@ -67,7 +67,7 @@
     </dependency>
     <dependency>
       <groupId>org.blaze</groupId>
-      <artifactId>hadoop-shim</artifactId>
+      <artifactId>hadoop-shim_${scalaVersion}</artifactId>
       <version>${revision}</version>
     </dependency>
     <dependency>

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/arrowio/util/ArrowUtils.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/arrowio/util/ArrowUtils.scala
@@ -132,7 +132,7 @@ object ArrowUtils {
         val fields = field.getChildren.asScala.map { child =>
           val dt = fromArrowField(child)
           StructField(child.getName, dt, child.isNullable)
-        }
+        }.toSeq
         StructType(fields)
       case arrowType => fromArrowType(arrowType)
     }
@@ -151,6 +151,6 @@ object ArrowUtils {
     StructType(schema.getFields.asScala.map { field =>
       val dt = fromArrowField(field)
       StructField(field.getName, dt, field.isNullable)
-    })
+    }.toSeq)
   }
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeFileSourceScanBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeFileSourceScanBase.scala
@@ -70,7 +70,8 @@ abstract class NativeFileSourceScanBase(basedFileScan: FileSourceScanExec)
     .flatMap(_.files)
     .groupBy(_.filePath)
     .mapValues(_.foldLeft(0L)(_ + _.length))
-    .map(identity) // make this map serializable
+    .map(identity)
+    .toMap // make this map serializable
 
   protected def nativePruningPredicateFilters: Seq[pb.PhysicalExprNode] =
     basedFileScan.dataFilters

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeFileSourceScanBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeFileSourceScanBase.scala
@@ -70,8 +70,8 @@ abstract class NativeFileSourceScanBase(basedFileScan: FileSourceScanExec)
     .flatMap(_.files)
     .groupBy(_.filePath)
     .mapValues(_.foldLeft(0L)(_ + _.length))
-    .map(identity)
-    .toMap // make this map serializable
+    .map(identity) // make this map serializable
+    .toMap
 
   protected def nativePruningPredicateFilters: Seq[pb.PhysicalExprNode] =
     basedFileScan.dataFilters

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeGenerateBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeGenerateBase.scala
@@ -110,7 +110,7 @@ abstract class NativeGenerateBase(
             .newBuilder()
             .setSerialized(ByteString.copyFrom(NativeConverters.serializeExpression(
               bound.asInstanceOf[Generator with Serializable],
-              StructType(paramsFields))))
+              StructType(paramsFields.toSeq))))
             .setReturnSchema(NativeConverters.convertSchema(udtf.elementSchema)))
         .addAllChild(children.map(NativeConverters.convertExpr).asJava)
         .build()

--- a/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/blaze/plan/NativeHiveTableScanBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/blaze/plan/NativeHiveTableScanBase.scala
@@ -62,8 +62,8 @@ abstract class NativeHiveTableScanBase(basedHiveScan: HiveTableScanExec)
     .flatMap(_.files)
     .groupBy(_.filePath)
     .mapValues(_.foldLeft(0L)(_ + _.length))
-    .map(identity)
-    .toMap // make this map serializable
+    .map(identity) // make this map serializable
+    .toMap
 
   // should not include partition columns
   protected def nativeFileSchema: pb.Schema =

--- a/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/blaze/plan/NativeHiveTableScanBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/blaze/plan/NativeHiveTableScanBase.scala
@@ -16,7 +16,6 @@
 package org.apache.spark.sql.hive.execution.blaze.plan
 
 import scala.collection.JavaConverters._
-import scala.collection.Seq
 
 import org.apache.hadoop.fs.FileSystem
 import org.apache.spark.broadcast.Broadcast
@@ -26,7 +25,6 @@ import org.apache.spark.sql.blaze.NativeHelper
 import org.apache.spark.sql.blaze.NativeSupports
 import org.apache.spark.sql.blaze.Shims
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
-import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.LeafExecNode
 import org.apache.spark.sql.execution.SparkPlan
@@ -52,7 +50,7 @@ abstract class NativeHiveTableScanBase(basedHiveScan: HiveTableScanExec)
   override lazy val metrics: Map[String, SQLMetric] =
     NativeHelper.getNativeFileScanMetrics(sparkContext)
 
-  override val output: Seq[Attribute] = basedHiveScan.output
+  override val output = basedHiveScan.output.toSeq
   override val outputPartitioning: Partitioning = basedHiveScan.outputPartitioning
 
   protected val relation: HiveTableRelation = basedHiveScan.relation
@@ -64,7 +62,8 @@ abstract class NativeHiveTableScanBase(basedHiveScan: HiveTableScanExec)
     .flatMap(_.files)
     .groupBy(_.filePath)
     .mapValues(_.foldLeft(0L)(_ + _.length))
-    .map(identity) // make this map serializable
+    .map(identity)
+    .toMap // make this map serializable
 
   // should not include partition columns
   protected def nativeFileSchema: pb.Schema =

--- a/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/blaze/plan/NativePaimonTableScanExec.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/blaze/plan/NativePaimonTableScanExec.scala
@@ -203,6 +203,7 @@ case class NativePaimonTableScanExec(basedHiveScan: HiveTableScanExec)
         }
       }
       .sortBy(_.length)(implicitly[Ordering[Long]].reverse)
+      .toSeq
     FilePartition.getFilePartitions(sparkSession, partitionedFiles, maxSplitBytes).toArray
   }
 

--- a/spark-version-annotation-macros/pom.xml
+++ b/spark-version-annotation-macros/pom.xml
@@ -4,12 +4,12 @@
 
   <parent>
     <groupId>org.blaze</groupId>
-    <artifactId>blaze-engine</artifactId>
+    <artifactId>blaze-engine_${scalaVersion}</artifactId>
     <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>org.blaze</groupId>
-  <artifactId>spark-version-annotation-macros</artifactId>
+  <artifactId>spark-version-annotation-macros_${scalaVersion}</artifactId>
   <packaging>jar</packaging>
 
   <dependencies>
@@ -28,20 +28,31 @@
       <artifactId>scala-reflect</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.scalamacros</groupId>
-      <artifactId>paradise_${scalaLongVersion}</artifactId>
-      <version>2.1.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.scala-lang</groupId>
-          <artifactId>scala-compiler</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.scala-lang</groupId>
-          <artifactId>scala-reflect</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>scala-2.12</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.scalamacros</groupId>
+          <artifactId>paradise_${scalaLongVersion}</artifactId>
+          <version>${scalamacros.paradise.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>org.scala-lang</groupId>
+              <artifactId>scala-compiler</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.scala-lang</groupId>
+              <artifactId>scala-reflect</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/spark-version-annotation-macros/pom.xml
+++ b/spark-version-annotation-macros/pom.xml
@@ -34,7 +34,10 @@
     <profile>
       <id>scala-2.12</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>scalaVersion</name>
+          <value>2.12</value>
+        </property>
       </activation>
       <dependencies>
         <dependency>

--- a/spark-version-annotation-macros/src/main/scala/org/blaze/sparkver.scala
+++ b/spark-version-annotation-macros/src/main/scala/org/blaze/sparkver.scala
@@ -60,9 +60,9 @@ object sparkver {
 
       impl(c)(annottees: _*) {
         val head = annottees.head.tree match {
-          case ClassDef(mods, name, tparams, Template(parents, self, _body)) =>
+          case ClassDef(mods, name, tparams, Template(parents, self, _)) =>
             ClassDef(mods, name, tparams, Template(parents, self, List(EmptyTree)))
-          case ModuleDef(mods, name, Template(parents, self, _body)) =>
+          case ModuleDef(mods, name, Template(parents, self, _)) =>
             ModuleDef(mods, name, Template(parents, self, List(EmptyTree)))
         }
         c.Expr(q"$head; ..${annottees.tail}")

--- a/spark-version-annotation-macros/src/main/scala/org/blaze/sparkver.scala
+++ b/spark-version-annotation-macros/src/main/scala/org/blaze/sparkver.scala
@@ -60,9 +60,9 @@ object sparkver {
 
       impl(c)(annottees: _*) {
         val head = annottees.head.tree match {
-          case ClassDef(mods, name, tparams, Template(parents, self, _)) =>
+          case ClassDef(mods, name, tparams, Template(parents, self, _body)) =>
             ClassDef(mods, name, tparams, Template(parents, self, List(EmptyTree)))
-          case ModuleDef(mods, name, Template(parents, self, _)) =>
+          case ModuleDef(mods, name, Template(parents, self, _body)) =>
             ModuleDef(mods, name, Template(parents, self, List(EmptyTree)))
         }
         c.Expr(q"$head; ..${annottees.tail}")


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1127 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
It should be a general requirement that we need to support build blaze on scala-2.13.

And In fact, in our platform, we provide both spark binary on scala-2.12 and scala-2.13.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->


After this PR, when building the project, need to specify the scala profile or add `-DscalaVersion=2.12` or `-DscalaVersion=2.13` to activate the scala profile.