### PR TITLE
Support to show `os.detected.classfier` for blaze jar

### DIFF
--- a/.github/workflows/build-ce7-releases.yml
+++ b/.github/workflows/build-ce7-releases.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         sparkver: [spark-3.0, spark-3.1, spark-3.2, spark-3.3, spark-3.4, spark-3.5]
         blazever: [5.0.0]
+        osclassfier: [linux-x86_64]
 
     steps:
       - uses: actions/checkout@v4
@@ -26,8 +27,8 @@ jobs:
         id: cache
         uses: actions/cache@v3
         with:
-          path: target-docker/blaze-engine-${{matrix.sparkver}}-release-${{ matrix.blazever }}-SNAPSHOT.jar
-          key: blaze-engine-${{matrix.sparkver}}-release-${{ matrix.blazever }}-SNAPSHOT.jar
+          path: target-docker/blaze-engine-${{matrix.sparkver}}-release-${{ matrix.osclassfier }}-${{ matrix.blazever }}-SNAPSHOT.jar
+          key: blaze-engine-${{matrix.sparkver}}-release-${{ matrix.osclassfier }}-${{ matrix.blazever }}-SNAPSHOT.jar
 
       - uses: ScribeMD/rootless-docker@0.2.2
         if: steps.cache.outputs.cache-hit != 'true'
@@ -45,6 +46,6 @@ jobs:
       - name: Upload blaze-engine-${{ matrix.sparkver }}
         uses: actions/upload-artifact@v4
         with:
-          name: blaze-engine-${{matrix.sparkver}}-release-${{ matrix.blazever }}-SNAPSHOT-ce7-${{ steps.commit.outputs.short }}.jar
-          path: target-docker/blaze-engine-${{matrix.sparkver}}-release-${{ matrix.blazever }}-SNAPSHOT.jar
+          name: blaze-engine-${{matrix.sparkver}}-release-${{ matrix.osclassfier }}-${{ matrix.blazever }}-SNAPSHOT-ce7-${{ steps.commit.outputs.short }}.jar
+          path: target-docker/blaze-engine-${{matrix.sparkver}}-release-${{ matrix.osclassfier }}-${{ matrix.blazever }}-SNAPSHOT.jar
           overwrite: true

--- a/.github/workflows/build-ce7-releases.yml
+++ b/.github/workflows/build-ce7-releases.yml
@@ -1,7 +1,6 @@
 name: Build Centos7 Releases
 
 on:
-  pull_request:
   workflow_dispatch:
   push:
     branches: ["master"]

--- a/.github/workflows/build-ce7-releases.yml
+++ b/.github/workflows/build-ce7-releases.yml
@@ -1,6 +1,7 @@
 name: Build Centos7 Releases
 
 on:
+  pull_request:
   workflow_dispatch:
   push:
     branches: ["master"]

--- a/dev/docker-build/docker-compose.yml
+++ b/dev/docker-build/docker-compose.yml
@@ -19,4 +19,4 @@ services:
       SHIM: "${SHIM}"
       MODE: "${MODE}"
       JAVA_VERSION: "${JAVA_VERSION}"
-    command: "bash -c 'source ~/.bashrc && cd /blaze && mvn -T8 package -P${SHIM} -P${MODE} -Pjdk-${JAVA_VERSION}'"
+    command: "bash -c 'source ~/.bashrc && cd /blaze && ./build/mvn -T8 package -P${SHIM} -P${MODE} -Pjdk-${JAVA_VERSION}'"

--- a/dev/docker-build/docker-compose.yml
+++ b/dev/docker-build/docker-compose.yml
@@ -19,4 +19,4 @@ services:
       SHIM: "${SHIM}"
       MODE: "${MODE}"
       JAVA_VERSION: "${JAVA_VERSION}"
-    command: "bash -c 'source ~/.bashrc && cd /blaze && ./build/mvn -T8 package -P${SHIM} -P${MODE} -Pjdk-${JAVA_VERSION}'"
+    command: "bash -c 'source ~/.bashrc && cd /blaze && mvn -T8 package -P${SHIM} -P${MODE} -Pjdk-${JAVA_VERSION}'"

--- a/dev/mvn-build-helper/assembly/pom.xml
+++ b/dev/mvn-build-helper/assembly/pom.xml
@@ -110,11 +110,19 @@
               <archive>
                 <addMavenDescriptor>false</addMavenDescriptor>
               </archive>
-              <outputFile>../../../target/blaze-engine-${shimName}-${releaseMode}-${revision}.jar</outputFile>
+              <outputFile>../../../target/blaze-engine-${shimName}-${releaseMode}-${os.detected.classifier}-${revision}.jar</outputFile>
             </configuration>
           </execution>
         </executions>
       </plugin>
     </plugins>
+    <extensions>
+      <!-- provides os.detected.classifier (i.e. linux-x86_64, osx-x86_64) property -->
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>${os-maven-plugin.version}</version>
+      </extension>
+    </extensions>
   </build>
 </project>

--- a/dev/mvn-build-helper/proto/pom.xml
+++ b/dev/mvn-build-helper/proto/pom.xml
@@ -49,7 +49,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <version>${os-maven-plugin.version}</version>
       </extension>
     </extensions>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <maven.version>3.8.1</maven.version>
     <maven.plugin.scala.version>4.9.2</maven.plugin.scala.version>
     <maven.plugin.shade.version>3.5.2</maven.plugin.shade.version>
-    <os-maven-plugin.version>1.6.0</os-maven-plugin.version>
+    <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <maven.version>3.8.1</maven.version>
     <maven.plugin.scala.version>4.9.2</maven.plugin.scala.version>
     <maven.plugin.shade.version>3.5.2</maven.plugin.shade.version>
-    <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
+    <os-maven-plugin.version>1.6.0</os-maven-plugin.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <maven.version>3.8.1</maven.version>
     <maven.plugin.scala.version>4.9.2</maven.plugin.scala.version>
     <maven.plugin.shade.version>3.5.2</maven.plugin.shade.version>
+    <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

It is user friendly to know the OS where build the blaze jar.
```
ls target 

blaze-engine-spark-3.5-release-osx-aarch_64-5.0.0-SNAPSHOT.jar
```

<img width="1727" height="860" alt="image" src="https://github.com/user-attachments/assets/f29b1bb7-4f32-4255-b129-d4c5cdfd3d97" />

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
As title.
# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
Yes, user can know the jar `od.detected.classfier`.