### PR TITLE
[BLAZE-1114][FOLLOWUP] Reduce GA number for cross JDK versions testing

### DIFF
--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -37,27 +37,12 @@ jobs:
       sparkver: spark-3.3
       sparkurl: https://mirrors.huaweicloud.com/apache/spark/spark-3.3.4/spark-3.3.4-bin-hadoop3.tgz
 
-  test-spark-34:
+  test-spark-34-jdk11:
     name: Test spark-3.4
     uses: ./.github/workflows/tpcds-reusable.yml
     with:
       sparkver: spark-3.4
       sparkurl: https://mirrors.huaweicloud.com/apache/spark/spark-3.4.3/spark-3.4.3-bin-hadoop3.tgz
-
-  test-spark-35:
-    name: Test spark-3.5 JDK8
-    uses: ./.github/workflows/tpcds-reusable.yml
-    with:
-      sparkver: spark-3.5
-      sparkurl: https://archive.apache.org/dist/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz
-      javaver: '8'
-
-  test-spark-35-jdk11:
-    name: Test spark-3.5 JDK11
-    uses: ./.github/workflows/tpcds-reusable.yml
-    with:
-      sparkver: spark-3.5
-      sparkurl: https://archive.apache.org/dist/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz
       javaver: '11'
 
   test-spark-35-jdk17:


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

I am adding integration testing for celeborn and uniffle, there might be more and more GA workflows in the future.

This PR is to reduce the GA number for cross JDK versions testing.
 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Remove the GA number for cross JDK versions testing:
JDK8:
- spark-3.0
- spark-3.1
- spark-3.2
- spark-3.3

JDK11:
- spark-3.4

JDK17:
- spark-3.5

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
