### PR TITLE
reduce NotImplementedError log length

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/NativeConverters.scala
@@ -249,6 +249,8 @@ object NativeConverters extends Logging {
       override val children: Seq[Expression] = Nil)
       extends Unevaluable {
     val wrapped: PhysicalExprNode = _wrapped
+
+    override def toString(): String = s"$getClass() dataType:$dataType)"
   }
 
   def convertExpr(sparkExpr: Expression): pb.PhysicalExprNode = {


### PR DESCRIPTION
# Which issue does this PR close?


Closes #.

 # Rationale for this change

When encountering unsupported functions, a large number of logs will be output, such as this SQL, which outputs 6,000 characters.

```sql
select map(id,map(id+1,id+2)) as c1 from range(10);
```



# What changes are included in this PR?

# Are there any user-facing changes?

