### PR TITLE
[BLAZE-1162] Improve error handling by propagating detailed error messages

### DIFF
--- a/native-engine/blaze-serde/src/from_proto.rs
+++ b/native-engine/blaze-serde/src/from_proto.rs
@@ -308,7 +308,10 @@ impl TryInto<Arc<dyn ExecutionPlan>> for &protobuf::PhysicalPlanNode {
             }
             PhysicalPlanType::Sort(sort) => {
                 let input: Arc<dyn ExecutionPlan> = convert_box_required!(sort.input)?;
-                let exprs = try_parse_physical_sort_expr(&input, sort).unwrap();
+                let exprs = try_parse_physical_sort_expr(&input, sort).unwrap_or_else(|e| {
+                    panic!("Failed to parse physical sort expressions: {}", e);
+                });
+
                 // always preserve partitioning
                 Ok(Arc::new(SortExec::new(
                     input,
@@ -1062,7 +1065,7 @@ fn try_parse_physical_expr_box_required(
 fn try_parse_physical_sort_expr(
     input: &Arc<dyn ExecutionPlan>,
     sort: &Box<SortExecNode>,
-) -> Option<Vec<PhysicalSortExpr>> {
+) -> Result<Vec<PhysicalSortExpr>, PlanSerDeError> {
     let pyhsical_sort_expr = sort
         .expr
         .iter()
@@ -1098,9 +1101,8 @@ fn try_parse_physical_sort_expr(
                 )))
             }
         })
-        .collect::<Result<Vec<_>, _>>()
-        .ok()?;
-    Some(pyhsical_sort_expr)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(pyhsical_sort_expr)
 }
 
 pub fn parse_protobuf_partitioning(
@@ -1140,7 +1142,9 @@ pub fn parse_protobuf_partitioning(
                     Ok(Some(Partitioning::SinglePartitioning()))
                 } else {
                     let sort = range_part.sort_expr.clone().unwrap();
-                    let exprs = try_parse_physical_sort_expr(&input, &sort).unwrap();
+                    let exprs = try_parse_physical_sort_expr(&input, &sort).unwrap_or_else(|e| {
+                        panic!("Failed to parse physical sort expressions: {}", e);
+                    });
 
                     let value_list: Vec<ScalarValue> = range_part
                         .list_value


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1162.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This PR improves the error reporting and visibility in the function `try_parse_physical_sort_expr` by changing the return type from `Option<Vec<PhysicalSortExpr>>` to `Result<Vec<PhysicalSortExpr>, PlanSerDeError>`.

Previously, when the function failed (e.g., due to schema mismatch), it silently returned None, and the caller used .unwrap() or similar logic, which resulted in non-informative runtime panics such as:
```
Caused by: java.lang.RuntimeException: called `Option::unwrap()` on a `None` value

```

This made it difficult to diagnose the actual root cause, such as schema mismatches or invalid expression structures.

After this PR:
```
Caused by: java.lang.RuntimeException: Failed to parse physical sort expressions: Arrow error: Schema error: Unable to get field named "#520". Valid fields: ["#460", "#463"]

```
# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* Changed return type of try_parse_physical_sort_expr(...) from Option<_> to Result<_, PlanSerDeError>.

* Propagated detailed error messages, including internal ArrowErrors when parsing fails.

* Caller now receives the actual error, for example:


```
ArrowError(SchemaError("Unable to get field named \"#520\". Valid fields: [\"#460\", \"#463\"]"))
```

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

NO.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

